### PR TITLE
stats: average + headline count over live facts (exclude owner-forgotten)

### DIFF
--- a/hv
+++ b/hv
@@ -920,14 +920,21 @@ def merkle_cmd(args):
 def stats(args):
     """Show memory usage stats."""
     conn = get_conn()
-    facts = conn.execute("SELECT count(*) FROM facts").fetchone()[0]
+    total_facts = conn.execute("SELECT count(*) FROM facts").fetchone()[0]
+    # Average + headline count over LIVE facts only. Owner-forgotten facts sit at FORGET_FLOOR
+    # (-1.0); counting them would drag the average down as the corpus gets *cleaner* — backwards.
+    # This mirrors the audit, which already excludes base <= FORGET_FLOOR.
+    live_facts = conn.execute(
+        "SELECT count(*) FROM facts WHERE confidence > ?", (FORGET_FLOOR,)).fetchone()[0]
+    forgotten_facts = total_facts - live_facts
     decisions = conn.execute("SELECT count(*) FROM decisions").fetchone()[0]
     active_decisions = conn.execute(
         "SELECT count(*) FROM decisions WHERE superseded_by IS NULL"
     ).fetchone()[0]
     entities = conn.execute("SELECT count(*) FROM entities").fetchone()[0]
     links = conn.execute("SELECT count(*) FROM entity_facts").fetchone()[0]
-    avg_conf = conn.execute("SELECT round(avg(confidence), 2) FROM facts").fetchone()[0] or 0
+    avg_conf = conn.execute(
+        "SELECT round(avg(confidence), 2) FROM facts WHERE confidence > ?", (FORGET_FLOOR,)).fetchone()[0] or 0
     top_tags = conn.execute("""
         SELECT tags, count(*) as cnt FROM facts WHERE tags IS NOT NULL
         GROUP BY tags ORDER BY cnt DESC LIMIT 5
@@ -941,7 +948,10 @@ def stats(args):
 
     print(f"Hive Mind Stats — {HIVE_HOME}")
     print(f"  Node:               {NODE_ID}")
-    print(f"  Facts:              {facts}  (avg confidence: {avg_conf})")
+    facts_line = f"{live_facts} live  (avg confidence: {avg_conf})"
+    if forgotten_facts:
+        facts_line += f"  +{forgotten_facts} forgotten"
+    print(f"  Facts:              {facts_line}")
     print(f"  Decisions:          {decisions}  ({active_decisions} active)")
     print(f"  Entities:           {entities}  ({links} fact-links)")
     print(f"  Journal entries:    {len(entries)}  ({', '.join(f'{k}={v}' for k, v in sorted(by_node.items())) or 'empty'})")

--- a/tests/test_hv.py
+++ b/tests/test_hv.py
@@ -38,6 +38,19 @@ def test_remember_and_fts_search(hive):
     assert "real estate" in hive.run("search", "real estate").stdout
 
 
+def test_stats_excludes_forgotten_from_average(hive):
+    import re
+    hive.run("remember", "fact alpha is true", "--source", "alice")
+    out = hive.run("remember", "fact beta is true", "--source", "bob").stdout
+    fid = re.search(r"#(\d+)", out).group(1)
+    hive.run("retract", fid, "--owner")          # -> FORGET_FLOOR (-1.0)
+    s = hive.run("stats").stdout
+    assert "1 live" in s and "1 forgotten" in s, s
+    # average is over the live fact (~0.45), NOT dragged toward -1.0 by the forgotten one
+    m = re.search(r"avg confidence: ([\-0-9.]+)", s)
+    assert m and float(m.group(1)) > 0, s
+
+
 def test_search_punctuation_does_not_crash(hive):
     hive.run("remember", "uses C++ and (parens)")
     r = hive.run("search", 'C++ (parens) & punctuation!')


### PR DESCRIPTION
## Problem
`hv stats` counted and averaged confidence over **all** facts, including owner-forgotten ones (confidence `-1.0`). As the corpus gets *cleaner* (more dups/telemetry/test facts forgotten), the average gets *worse* — backwards. After recent cleanups the real corpus showed a misleading `avg confidence: 0.19` when the ~116 live facts are all at the healthy `0.45` floor.

## Fix
Count and average over **live facts only** (`confidence > FORGET_FLOOR`), mirroring the exclusion the audit already uses, and show forgotten separately.

```
before:  Facts: 141       (avg confidence: 0.19)
after:   Facts: 116 live  (avg confidence: 0.45)  +25 forgotten
```

## Notes
- Read-only/display change; no schema or behavior change elsewhere.
- Regression test added: `tests/test_hv.py::test_stats_excludes_forgotten_from_average`.
- Full suite: 58 passing.
- Branched to avoid colliding with Hermes's work on `main`; CI re-signs the manifest on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)