### PR TITLE
ci(sign): install pytest so the release-sign gate can run the suite

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -37,7 +37,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'        # match ci.yml — the sign gate runs the same suite
+
+      - name: Install test deps
+        run: pip install -r requirements.txt pytest   # sign_release.py's gate runs `python3 -m pytest`
 
       - name: Regenerate manifest
         run: python3 scripts/gen_verify.py


### PR DESCRIPTION
## Why

PR #9 added the release-sign-on-green gate: `sign_release.py` runs `python3 -m pytest` and refuses to sign a red tree. But `sign.yml` never installed pytest (and ran on py3.14), so on the post-merge run the gate read **'No module named pytest'** as 'tests RED' and **correctly refused to sign** — failing safe, but leaving `main`'s manifest unsigned.

## Fix

Install `-r requirements.txt pytest` and pin Python 3.12 to match `ci.yml`, so the sign job runs the same suite and a signed `verify.json` again implies a green suite.

## Effect

On merge, `sign.yml` re-runs, executes the full suite (test-gated), signs `verify.json`, and commits it back — unblocking the 1.14 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)