### PR TITLE
feat(security): trust only identity-derived device keys for capsules

### DIFF
--- a/hv
+++ b/hv
@@ -3173,10 +3173,14 @@ _CAPSULE_ALG = "x25519-hkdf-chacha20poly1305-v1"
 def _recipient_pubkeys(entries, gov):
     """{device_id: curve_pub bytes} for the current authorized set (admitted − purged). A device's
     Ed25519 pubkey is harvested from its OWN signed entries (pub bound to node_id via the
-    fingerprint) and converted to Curve25519; a curve_pub carried on its join-request/admit is a
-    fallback. Returns (recipients, missing) — `missing` = admitted device_ids with no usable key yet."""
+    fingerprint) and converted to Curve25519 — this identity-derived key is the ONLY trusted key
+    source, since it is cryptographically bound to the device's signing identity. A curve_pub
+    merely *carried* on a join-request/admit payload has NO proof-of-possession, so it is never
+    used as a key; it is only checked for disagreement with the derived value (a tamper signal).
+    Returns (recipients, missing, suspect): `missing` = admitted device_ids with no derivable key
+    yet; `suspect` = device_ids that carried a curve_pub absent-or-unequal to the derived one."""
     if _x25519 is None:
-        return {}, sorted(gov.get("admitted", set()) - gov.get("purged", set()))
+        return {}, sorted(gov.get("admitted", set()) - gov.get("purged", set())), set()
     admitted = gov.get("admitted", set()) - gov.get("purged", set())
     ed_pub_by_dev, carried = {}, {}
     for e in entries:
@@ -3192,7 +3196,7 @@ def _recipient_pubkeys(entries, gov):
             p = e.get("payload", {})
             if p.get("action") in ("join-request", "admit") and p.get("curve_pub") and p.get("device_id"):
                 carried[p["device_id"]] = p["curve_pub"]
-    recips, missing = {}, []
+    recips, missing, suspect = {}, [], set()
     for dev in sorted(admitted):
         cp = None
         if dev in ed_pub_by_dev:
@@ -3200,14 +3204,18 @@ def _recipient_pubkeys(entries, gov):
                 cp = _x25519.ed_pub_to_curve_pub(ed_pub_by_dev[dev])
             except Exception:
                 cp = None
-        if cp is None and dev in carried:
+        if dev in carried:
+            # A carried curve_pub is never a key source (no proof-of-possession). Flag it as
+            # suspect unless it exactly matches the identity-derived key — a planted, contradictory
+            # value is the signal that someone tried to redirect this device's capsules.
             try:
                 raw = base64.b64decode(carried[dev])
-                cp = raw if len(raw) == 32 else None
             except Exception:
-                cp = None
+                raw = None
+            if cp is None or raw != cp:
+                suspect.add(dev)
         (recips.__setitem__(dev, cp) if cp is not None else missing.append(dev))
-    return recips, missing
+    return recips, missing, suspect
 
 
 def _capsule_build(name, kind, value, recipients, version, hive_id, signer):
@@ -3355,7 +3363,7 @@ def capsule_cmd(args):
                       "owner device, or `hv config governance set capsule_putters fertile`."); return 1
             if putters == "fertile" and NODE_ID not in gov.get("admitted", set()):
                 print("Only admitted devices may store capsules on this hive."); return 1
-        recips, missing = _recipient_pubkeys(entries, gov)
+        recips, missing, suspect = _recipient_pubkeys(entries, gov)
         if not recips:                                  # pre-owner / solo: seal to THIS device
             sc = _my_curve_scalar()
             if sc is not None:
@@ -3393,6 +3401,9 @@ def capsule_cmd(args):
         if missing:
             msg += (f" WARNING: {len(missing)} admitted device(s) have no published pubkey yet and "
                     f"cannot open it until you rotate after they sync.")
+        if suspect:
+            msg += (f" SECURITY: {len(suspect)} device(s) carried a curve_pub that disagrees with "
+                    f"their identity-derived key — IGNORED (not trusted): {', '.join(sorted(suspect))}.")
         print(msg)
         print("Note: a device removed later can still open an OLD version it already synced — rotate "
               "the upstream secret to truly cut access.")
@@ -3584,6 +3595,32 @@ def _doctor_status():
             checks.append({"name": "owner", "status": status, "detail": detail})
     except Exception as e:
         checks.append({"name": "owner", "status": "warn", "detail": f"owner check error: {e}"})
+
+    # 3b. Device keys — every admitted device must have a usable Curve25519 key derived from its
+    #     OWN signed identity (capsules seal to that). `missing` = admitted but hasn't synced a
+    #     signed entry yet (normal/transient → warn, never fail). `suspect` = a curve_pub was
+    #     carried on its join/admit that disagrees with the identity-derived key; it is IGNORED
+    #     (never trusted), but a disagreement is a tamper signal worth surfacing.
+    if _x25519 is None:
+        checks.append({"name": "device-keys", "status": "ok", "detail": "n/a (crypto lib absent)"})
+    else:
+        try:
+            dgov = _governance_state(entries)
+            _, missing, suspect = _recipient_pubkeys(entries, dgov)
+            if suspect:
+                checks.append({"name": "device-keys", "status": "warn",
+                               "detail": f"{len(suspect)} device(s) carried a curve_pub that disagrees with "
+                                         f"their identity-derived key — IGNORED: {', '.join(sorted(suspect))}"
+                                         + (f"; {len(missing)} admitted device(s) have no synced key yet" if missing else "")})
+            elif missing:
+                checks.append({"name": "device-keys", "status": "warn",
+                               "detail": f"{len(missing)} admitted device(s) have no synced device key yet "
+                                         f"(can't receive capsules until they sync): {', '.join(missing)}"})
+            else:
+                checks.append({"name": "device-keys", "status": "ok",
+                               "detail": "all admitted devices have an identity-derived capsule key"})
+        except Exception as e:
+            checks.append({"name": "device-keys", "status": "warn", "detail": f"check error: {e}"})
 
     # 4. Hygiene — duplicates / obsolete / re-check, as surfaced by the audit. Advisory only.
     try:
@@ -4314,6 +4351,18 @@ def _group_list():
         print(f"purged ({len(gov['purged'])}):")
         for d in sorted(gov["purged"]):
             print(f"  {d}")
+    if _x25519 is None:
+        print("device keys: n/a (crypto lib absent)")
+    else:
+        _, missing, suspect = _recipient_pubkeys(entries, gov)
+        if missing:
+            print(f"missing keys ({len(missing)}):  # admitted but no synced device key yet — can't receive capsules")
+            for d in missing:
+                print(f"  {d}")
+        if suspect:
+            print(f"SECURITY — carried curve_pub disagrees with identity-derived key, ignored ({len(suspect)}):")
+            for d in sorted(suspect):
+                print(f"  {d}")
 
 
 def group_cmd(args):
@@ -4445,12 +4494,19 @@ def join_cmd(args):
     Non-blocking — you're already syncing the hive; your writes simply do not count toward
     confidence until the owner admits you. The request is device-signed (not owner-signed), so it
     carries no authority — it's only a visible, pending ask."""
-    gov = _governance_state(merkle.read_all_entries(JOURNAL_DIR))
+    entries = merkle.read_all_entries(JOURNAL_DIR)
+    gov = _governance_state(entries)
     if not gov["owner_id"]:
         print("No owner is established in this hive yet (have you synced it?). Nothing to join.")
         return
     if NODE_ID in gov["admitted"]:
         print(f"This device ({NODE_ID}) is already admitted.")
+        return
+    # Idempotent: don't pile up duplicate join-requests (journal hygiene, and it denies an
+    # attacker the ability to churn fresh payloads pre-admission). A DENIED device is excluded
+    # from _pending_admissions, so it can still re-ask after a denial.
+    if any(r["device_id"] == NODE_ID for r in _pending_admissions(entries, gov)):
+        print(f"Join request for {NODE_ID} is already pending — ask the owner to `hv admit {NODE_ID}`.")
         return
     payload = {"action": "join-request", "device_id": NODE_ID, "label": NODE_LABEL}
     if args.principal:

--- a/tests/test_recipient_pubkeys.py
+++ b/tests/test_recipient_pubkeys.py
@@ -1,0 +1,151 @@
+"""Security hardening — capsule recipient-key trust.
+
+`_recipient_pubkeys` must seal capsules ONLY to a Curve25519 key it can derive from a device's
+own signed Ed25519 identity (which is cryptographically bound to its device_id). A `curve_pub`
+merely *carried* on a join-request/admit payload has no proof-of-possession and must NEVER be
+trusted as a key source — it is only checked for disagreement (a tamper tripwire → `suspect`).
+
+Also pins `hv join` idempotency: a device cannot pile up duplicate (potentially curve_pub-churning)
+join-requests before admission.
+"""
+
+import base64
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT))
+import x25519        # noqa: E402
+import ed25519       # noqa: E402
+
+
+def _loadhv(home, monkeypatch):
+    monkeypatch.setenv("HIVE_HOME", str(home))
+    loader = importlib.machinery.SourceFileLoader("hvmod_rpk", str(PROJECT / "hv"))
+    spec = importlib.util.spec_from_loader("hvmod_rpk", loader)
+    m = importlib.util.module_from_spec(spec)
+    loader.exec_module(m)
+    return m
+
+
+def _b64(b):
+    return base64.b64encode(b).decode()
+
+
+def _identity_entry(hv, ed_pub, seq=1):
+    """A signed-shape entry whose node_id is the fingerprint of ed_pub (the binding harvest relies
+    on). _recipient_pubkeys checks node_id == _device_id_for_pub(pub); signature isn't re-verified
+    here (that happens at ingest), so a plain dict with the bound pub/node_id suffices."""
+    nid = hv._device_id_for_pub(ed_pub)
+    return nid, {"type": "fact", "node_id": nid, "seq": seq, "pub": _b64(ed_pub)}
+
+
+def _carried(device_id, curve_pub, signer_id="k1:owner000", action="join-request", seq=9):
+    return {"type": "governance", "node_id": signer_id, "seq": seq,
+            "payload": {"action": action, "device_id": device_id, "curve_pub": _b64(curve_pub)}}
+
+
+def _gov(admitted, purged=()):
+    return {"admitted": set(admitted), "purged": set(purged)}
+
+
+def test_identity_derived_key_is_used_on_the_honest_path(tmp_path, monkeypatch):
+    hv = _loadhv(tmp_path, monkeypatch)
+    seed = os.urandom(32)
+    ed_pub = ed25519.pub_from_seed(seed)
+    derived = x25519.ed_pub_to_curve_pub(ed_pub)
+    dev, ent = _identity_entry(hv, ed_pub)
+    recips, missing, suspect = hv._recipient_pubkeys([ent], _gov([dev]))
+    assert recips[dev] == derived          # sealed to the key derived from the signed identity
+    assert not missing and not suspect
+
+
+def test_carried_curve_pub_without_identity_is_never_trusted(tmp_path, monkeypatch):
+    """The core vuln: a device admitted with NO signed identity entry, but a curve_pub carried on a
+    join-request. Pre-fix this was sealed-to on sight (no proof-of-possession). It must now be
+    refused → the device is `missing`, never a recipient, and flagged `suspect`."""
+    hv = _loadhv(tmp_path, monkeypatch)
+    attacker_cp = os.urandom(32)
+    dev = "k1:victimdevice00"          # admitted, but never wrote a signed entry → no derivable key
+    entries = [_carried(dev, attacker_cp)]
+    recips, missing, suspect = hv._recipient_pubkeys(entries, _gov([dev]))
+    assert dev not in recips           # attacker-chosen key is NOT used
+    assert dev in missing
+    assert dev in suspect
+
+
+def test_carried_curve_pub_contradicting_identity_is_ignored_and_flagged(tmp_path, monkeypatch):
+    """Device HAS a signed identity, but an attacker also planted a different carried curve_pub.
+    The identity-derived key must win (carried never overrides), and the contradiction is a
+    tamper signal → `suspect`."""
+    hv = _loadhv(tmp_path, monkeypatch)
+    seed = os.urandom(32)
+    ed_pub = ed25519.pub_from_seed(seed)
+    derived = x25519.ed_pub_to_curve_pub(ed_pub)
+    dev, ident = _identity_entry(hv, ed_pub, seq=1)
+    wrong_cp = os.urandom(32)
+    entries = [ident, _carried(dev, wrong_cp)]
+    recips, missing, suspect = hv._recipient_pubkeys(entries, _gov([dev]))
+    assert recips[dev] == derived      # derived wins; the planted value is ignored
+    assert dev not in missing
+    assert dev in suspect
+
+
+def test_carried_curve_pub_matching_identity_is_not_suspect(tmp_path, monkeypatch):
+    """A carried curve_pub that exactly equals the derived value is honest/redundant — used (via
+    derivation) and NOT flagged."""
+    hv = _loadhv(tmp_path, monkeypatch)
+    seed = os.urandom(32)
+    ed_pub = ed25519.pub_from_seed(seed)
+    derived = x25519.ed_pub_to_curve_pub(ed_pub)
+    dev, ident = _identity_entry(hv, ed_pub, seq=1)
+    entries = [ident, _carried(dev, derived)]
+    recips, missing, suspect = hv._recipient_pubkeys(entries, _gov([dev]))
+    assert recips[dev] == derived
+    assert not missing and not suspect
+
+
+def test_purged_device_never_a_recipient_or_missing(tmp_path, monkeypatch):
+    hv = _loadhv(tmp_path, monkeypatch)
+    seed = os.urandom(32)
+    ed_pub = ed25519.pub_from_seed(seed)
+    dev, ident = _identity_entry(hv, ed_pub)
+    recips, missing, suspect = hv._recipient_pubkeys([ident], _gov([dev], purged=[dev]))
+    assert dev not in recips and dev not in missing
+
+
+def _run(home, *args, node_id=None):
+    env = dict(os.environ, HIVE_HOME=str(home), HIVE_IDENTITY_STASH=str(Path(home) / "stash"))
+    if node_id:
+        env["HIVE_NODE_ID"] = node_id
+    r = subprocess.run([sys.executable, str(PROJECT / "hv"), *args], env=env,
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    return r
+
+
+def _join_requests_for(home, device_id):
+    import merkle
+    entries = merkle.read_all_entries(str(Path(home) / "journal"))
+    return [e for e in entries
+            if e.get("type") == "governance"
+            and e.get("payload", {}).get("action") == "join-request"
+            and e["payload"].get("device_id") == device_id]
+
+
+def test_join_is_idempotent_no_duplicate_requests(tmp_path):
+    """A second `hv join` while a request is already pending must NOT append another join-request
+    (journal hygiene; denies pre-admission curve_pub churn)."""
+    home = tmp_path
+    _run(home, "owner", "init")                      # owner established (owner device)
+    member = "k1:joiner00000001"
+    _run(home, "join", node_id=member)               # first ask → one join-request
+    assert len(_join_requests_for(home, member)) == 1
+    out = _run(home, "join", node_id=member).stdout   # second ask → short-circuits
+    assert "already pending" in out.lower()
+    assert len(_join_requests_for(home, member)) == 1   # still exactly one


### PR DESCRIPTION
## Context
Manual review of the 1.14 capsule crypto found that capsule recipient keys had a **proof-of-possession gap**: `_recipient_pubkeys` would fall back to trusting a `curve_pub` *carried* on a join-request/admit payload, with no proof the device holds the matching private key. Dead today (neither `join` nor `admit` populate `curve_pub`), but latent — the moment one does, capsules would be sealed to an attacker-chosen key for that `device_id`.

## Change
- **Core:** seal only to the Curve25519 key **derived** from a device's own signed Ed25519 identity (bound to its `device_id` by construction). The carried value is no longer a key source — it's a tamper tripwire: if absent-or-unequal to the derived key, the device is reported `suspect` and ignored. Behavior-identical for every real device today; closes the latent hole.
- **Visibility:** surface `missing` / `suspect` in `hv group list` and a `device-keys` advisory **warn** in `hv doctor` (previously only hinted during `capsule put`).
- **Hygiene:** `hv join` is idempotent — a second request while one is pending is a no-op (denies pre-admission `curve_pub` churn); a denied device can still re-ask.

## Tests
New `tests/test_recipient_pubkeys.py` (6): PoP rejection (regression guard — fails against pre-fix code), contradiction-ignored-and-flagged, honest-path-unchanged, matching-carried-not-suspect, purged device, join idempotency. Full suite (185) + crypto self-test green.

## Also confirmed during review
`hivemind.pub` **is** published at the well-known URL and matches the bundled key (hive fact #303 was stale). HKDF/AAD/per-recipient-ephemeral properties confirmed sound — no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)