### PR TITLE
feat(security): hardening batch 2 — DoS limits, durability, governance & operability

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,90 @@
+# HiveMind threat model
+
+This is the authoritative statement of what HiveMind defends against, what it assumes, and what
+is explicitly out of scope. It is meant to be read alongside `INTERNALS.md` (mechanics) and
+`P2P_DESIGN.md` (sync). When a security-relevant change lands, update this file.
+
+## Trust assumptions (the security rests on these)
+
+1. **Local key files are 0600 and the host is not compromised.** Device and owner Ed25519 seeds
+   live in `HIVE_HOME/.device-key` and `.owner-key` as raw bytes at mode 0600. Anyone who can read
+   those files *is* that device/owner. `hv doctor` hard-fails on a group/other-readable key and
+   `--fix` re-tightens it (and now loudly reports if the chmod itself fails).
+2. **The journal is an append-only, signed G-Set.** Every entry is signed by its device key and
+   `node_id = "k1:"+sha256(pub)[:16]`, so an entry cannot be attributed to a device whose key you
+   do not hold. Governance acts that bear authority (owner/admit/config) additionally carry an owner
+   signature. The journal converges deterministically across nodes (dedup by `(node_id, seq)`), so
+   every honest node computes the same governance/confidence projection.
+3. **The network perimeter is Tailscale.** The sync daemon (`:9876`) is reachable by any device on
+   the tailnet. There is no application-layer authentication beyond network reachability + the
+   per-entry signatures above. Tailscale ACLs are the access-control boundary for *who can connect*.
+
+## Adversary model (what we actively defend against)
+
+Given the perimeter above, the realistic adversary is **a misbehaving or compromised tailnet peer**
+(not an arbitrary internet host), plus **local multi-process races** (the daemon and a CLI writing
+at once). Concretely:
+
+- **Resource exhaustion from one peer.** The daemon caps request bodies (413 over `MAX_BODY_BYTES`),
+  sets a per-connection read timeout (slow-loris), bounds concurrent handlers (503 when saturated),
+  and rate-limits per peer-IP (429). A single peer cannot OOM, wedge, or thread-exhaust a node.
+- **Forged identity / laundered corroboration.** Entry signatures are verified on ingest; an entry
+  whose `node_id` is not the fingerprint of its embedded pubkey, or whose signature fails, is
+  rejected. Content from a non-admitted device is dropped once an owner exists.
+- **Sealing a secret to an attacker-chosen key.** Capsule recipient keys are derived ONLY from a
+  device's own signed Ed25519 identity (X25519 conversion); a `curve_pub` merely *carried* on a
+  join/admit payload is never trusted as a key (it is only a tamper tripwire → `suspect`). A
+  low-order or malformed recipient key is skipped per-recipient and reported `unsealable`, never
+  silently sealed to. The X25519 ECDH rejects the all-zero (low-order) shared secret.
+- **Forged clock to trip succession early.** A quorum election's dead-man timer is anchored on the
+  proposal's `basis_ts`. A proposal whose `basis_ts` leads its OWN entry timestamp by more than a
+  small skew allowance is rejected — a deterministic, entry-time-only check (no wall-clock), so the
+  journal stays convergent. See "Known limitations" for the residual.
+- **Local write races.** Journal appends take an exclusive `flock`, so a daemon and a CLI writing
+  the same daily file cannot interleave mid-line and corrupt a record.
+- **Cross-hive contamination.** Sync refuses to merge journals whose `hive_id` differs.
+
+## Known limitations (in scope to document, NOT yet closed)
+
+- **Bootstrap / TOFU window.** Before an owner is established, the hive accepts entries permissively
+  so the genesis owner declaration can propagate, and owner establishment is trust-on-first-use: the
+  first valid self-signed `owner` declaration wins. An attacker who injects an `owner` declaration
+  before the legitimate one can front-run ownership. *Mitigation:* establish the owner before
+  exposing the daemon, and verify the genesis `hive_id`/`owner_id` out-of-band when joining. Closing
+  this in code is consensus-critical and deferred to its own change with multi-node convergence tests.
+- **Join-request replay semantics.** Join-requests are last-write-wins per `device_id`; a denied
+  device can re-ask, and clearing a deny makes an older request visible again. This is intended
+  (a device may legitimately re-request), but it is not replay-bounded. Documented, not changed.
+- **Timestamp forgery by a quorum-holding adversary.** The election skew bound rejects a `basis_ts`
+  that leads its own entry timestamp, but an adversary who already controls a voting quorum AND
+  forges the carrying entry's timestamp far into the future can still pre-arm the dead-man switch.
+  This only lets such an adversary *skip the waiting period* — controlling a quorum already permits
+  a legitimate takeover after the wait — and the forged entries sort anomalously late. Residual,
+  documented.
+
+## Cryptographic posture
+
+- Primitives are **pure-Python** (Ed25519, X25519, Ed25519↔Curve25519, ChaCha20-Poly1305 per
+  RFC 8439) so the tool is dependency-free and offline-resilient. They are **not constant-time**.
+- **Timing side-channels:** extracting a key via timing requires an attacker who can measure the
+  victim *process's* execution finely — i.e. local code execution or precise co-resident timing.
+  Under the trust model (0600 local keys; a local-code attacker has already won by reading the key
+  file directly), this is **out of scope**. Do not run HiveMind crypto as a remote oracle that
+  signs/decrypts attacker-chosen inputs and returns fine-grained timing.
+- A bundled crypto module that fails to import is now a hard `doctor` failure (`crypto-modules`),
+  because `_verify_entry` falls through to accepting entries unverified when Ed25519 is absent — that
+  degradation must be loud, not silent. Known-answer self-tests run on every `doctor` pass.
+
+## Operational / scaling characteristics
+
+- **Journal growth.** The journal is append-only and grows without bound; projections
+  (`_governance_state`, confidence) historically full-scanned it. The governance projection is now
+  memoized on a content signature of just the governance entries (the heavy Ed25519 verification +
+  election walk is skipped when governance is unchanged — the common case, since ordinary `fact`
+  writes don't touch it). Very large histories still benefit from periodic operational review;
+  streaming/indexed projection is a long-term item.
+- **Best-effort recovery.** A truncated/garbled journal line (e.g. a crash mid-write) is skipped on
+  read; `hv doctor` now surfaces the count so silent data loss is visible (`journal-integrity`).
+- **`hv doctor --fix` blast radius.** `--fix` kills orphan daemons (by argv match), restarts the
+  managed systemd unit, and rewrites the foreign Claude Code config (with a backup). Run
+  `hv doctor --fix --dry-run` to preview every mutating action before letting it run.

--- a/hv
+++ b/hv
@@ -21,6 +21,7 @@ Cross-node identity (Phase 2):
 import argparse
 import base64
 import collections
+import copy
 import hashlib
 import hmac
 import json
@@ -486,6 +487,28 @@ def _journal_path_for(timestamp):
     return JOURNAL_DIR / f"{timestamp[:10]}.jsonl"
 
 
+try:
+    import fcntl as _fcntl
+except Exception:                       # non-POSIX (e.g. Windows) — no flock available
+    _fcntl = None
+
+
+def _append_line(path, line):
+    """Append one serialized JSON line to a daily journal file under an EXCLUSIVE advisory lock, so a
+    concurrent daemon+CLI write (normal operation) can't interleave mid-line and corrupt the .jsonl.
+    A line can exceed PIPE_BUF (4096B), so O_APPEND alone is NOT atomic for our records — the lock is.
+    Released on close. flock is POSIX-only; without it we fall back to a plain append (single-writer
+    is the common case there, and the best-effort corrupt-line skip in merkle.read_all_entries remains
+    the second line of defense)."""
+    with open(path, "a") as f:
+        if _fcntl is not None:
+            try:
+                _fcntl.flock(f.fileno(), _fcntl.LOCK_EX)
+            except Exception:
+                pass
+        f.write(line + "\n")
+
+
 def append_journal(entry_type, payload, timestamp=None):
     """Mint and append a LOCAL journal entry. This is the core append API —
     every local write goes through here. Returns the full entry dict."""
@@ -502,8 +525,7 @@ def append_journal(entry_type, payload, timestamp=None):
     seed = _device_seed()
     if seed is not None:
         _sign_entry(entry, seed, _ed25519.pub_from_seed(seed))
-    with open(_journal_path_for(timestamp), "a") as f:
-        f.write(json.dumps(entry) + "\n")
+    _append_line(_journal_path_for(timestamp), json.dumps(entry))
     return entry
 
 
@@ -537,8 +559,7 @@ def append_foreign_entries(entries):
     accepted = duplicates = rejected = 0
 
     def _persist(e):
-        with open(_journal_path_for(e.get("timestamp", _now_iso())), "a") as f:
-            f.write(json.dumps(e) + "\n")
+        _append_line(_journal_path_for(e.get("timestamp", _now_iso())), json.dumps(e))
 
     # ── Pass 1: governance (owner-signed acts + authority-less join-requests) ────────────────────
     for e in entries:
@@ -683,6 +704,8 @@ CONF_CAP_SELF = 0.70            # ceiling when all corroboration traces to ONE p
 GOV_QUORUM_M = 0                # admitted voter-units needed to elect a new owner (0 = elections OFF)
 GOV_QUORUM_BY = "device"       # count quorum by "device" or by "principal"
 GOV_DEAD_MAN_DAYS = 30.0       # owner inactivity (no owner-signed act, incl. heartbeat) before an election can install
+GOV_ELECTION_SKEW_DAYS = 1.0 / 24.0   # max a proposal's basis_ts may lead its OWN entry timestamp (clock-skew
+                               # allowance); a further-future basis_ts is a forged inactivity anchor → rejected
 
 
 def _parse_source(source):
@@ -767,7 +790,50 @@ def _capsule_state(entries):
     return _projection_latest(entries, "capsule")
 
 
+def _capsule_version_conflicts(entries):
+    """Capsule names where the SAME version was sealed by MORE THAN ONE device — a concurrent
+    put/rotate that happened before the writers synced. The projection still resolves deterministically
+    by (version, timestamp, node_id, seq), so the hive stays converged, but it means one writer's value
+    silently lost the tie. Returns sorted [name] so `hv doctor` can surface it (version is a local
+    increment, not owner-signed — this is the visibility the design otherwise lacks)."""
+    seen = {}      # (name, version) -> set(node_id)
+    for e in entries:
+        if e.get("type") != "capsule":
+            continue
+        p = e.get("payload", {}) or {}
+        name, ver = p.get("name"), p.get("version")
+        if name is None or ver is None:
+            continue
+        seen.setdefault((name, ver), set()).add(e.get("node_id"))
+    return sorted({name for (name, _ver), nodes in seen.items() if len(nodes) > 1})
+
+
+_GOV_CACHE = {}     # signature(governance entries) -> projected gov dict (master copy, never handed out)
+
+
 def _governance_state(entries):
+    """Memoized wrapper over the (pure, deterministic) governance projection. The projection reads
+    ONLY governance entries, so the cache key is a content signature of just those — a plain `fact`
+    write (the common case) does not bust it, and the heavy work (sort + multi-stage election walk +
+    per-entry Ed25519 verification) is skipped on the long-lived daemon's repeated calls. The cached
+    value is the master; every caller gets a deep COPY so a caller mutating its result can never
+    corrupt the cache. Output is byte-identical to the uncached projection for the same journal."""
+    govs_raw = [e for e in entries if e.get("type") == "governance"]
+    sig = hashlib.sha256(
+        "\x01".join(
+            json.dumps([e.get("node_id"), e.get("seq"), e.get("timestamp"),
+                        e.get("sig"), e.get("payload")], sort_keys=True, separators=(",", ":"))
+            for e in govs_raw).encode()
+    ).hexdigest()
+    master = _GOV_CACHE.get(sig)
+    if master is None:
+        master = _governance_state_uncached(entries)
+        _GOV_CACHE.clear()              # journal grows monotonically; only the latest sig is ever reused
+        _GOV_CACHE[sig] = master
+    return copy.deepcopy(master)
+
+
+def _governance_state_uncached(entries):
     """Pure, deterministic projection over owner-signed `governance` entries → the established owner,
     the admitted device set, the principal map, and tunable config. Because it reads only the journal
     (which converges via the G-Set), every node derives the same governance state, so confidence stays
@@ -839,6 +905,13 @@ def _governance_state(entries):
                 basis_ts = p.get("basis_ts", "")
                 if not new_pub or not basis_ts or pid != _election_id(new_pub, basis_ts):
                     continue                   # malformed or not content-addressed to its body
+                # Deterministic clock-skew bound: basis_ts anchors the owner-inactivity measurement,
+                # so a FUTURE-dated basis_ts pre-arms the dead-man switch. It cannot legitimately lead
+                # the proposal's OWN entry timestamp (_ts) — both are stamped at propose time — so
+                # reject one that does, beyond a small skew allowance. Entry-time vs entry-time only:
+                # every node decides identically and the journal stays convergent (no wall-clock).
+                if _days_between(_ts, basis_ts) > GOV_ELECTION_SKEW_DAYS:
+                    continue
                 pr = proposals.get(pid)
                 if pr is None:
                     try:
@@ -2566,6 +2639,35 @@ def _identity_init(force):
     print("  Share the device_id + pubkey with peers (add them to .peers.json).")
 
 
+def _ensure_device_key():
+    """Auto-mint a device key on first use if this is a FRESH node, so joining/capsules work without a
+    manual `hv key init`. Returns True iff it just minted one (caller can notify). Safe by construction:
+    it NEVER splits identity — it refuses when a key already exists, when HIVE_NODE_ID overrides the
+    identity (tests / two instances on one box), or when the journal already has entries under this
+    hostname (that case is the coordinated migration path, not a silent re-mint)."""
+    global NODE_ID
+    if _ed25519 is None or DEVICE_KEY_PATH.exists() or os.environ.get("HIVE_NODE_ID"):
+        return False
+    try:
+        if any(e.get("node_id") == socket.gethostname()
+               for e in merkle.read_all_entries(JOURNAL_DIR)):
+            return False
+    except Exception:
+        return False
+    seed = os.urandom(32)
+    HIVE_HOME.mkdir(parents=True, exist_ok=True)
+    DEVICE_KEY_PATH.write_text(base64.b64encode(seed).decode() + "\n")
+    pub = _ed25519.pub_from_seed(seed)
+    did = _device_id_for_pub(pub)
+    DEVICE_ID_PATH.write_text(did + "\n")
+    try:
+        os.chmod(DEVICE_KEY_PATH, 0o600)
+    except Exception:
+        pass
+    NODE_ID = did                          # adopt the freshly minted identity for the rest of this run
+    return True
+
+
 def key_cmd(args):
     """[alias of `hv config identity`] Show or create this device's Ed25519 device identity."""
     action = getattr(args, "key_action", None) or "show"
@@ -2709,7 +2811,14 @@ def _sync_daemon_pids():
     try:
         out = subprocess.run(["pgrep", "-af", "sync daemon"],
                              capture_output=True, text=True, timeout=5).stdout
-    except Exception:
+    except FileNotFoundError:
+        # `pgrep` missing → we CANNOT enumerate orphans. Surface it instead of silently returning
+        # [] (which reads as "no orphans" and lets `--fix` skip cleanup without telling anyone).
+        print("doctor: `pgrep` not found — cannot detect orphan sync daemons on this host.",
+              file=sys.stderr)
+        return []
+    except Exception as e:
+        print(f"doctor: orphan-daemon scan failed ({e}).", file=sys.stderr)
         return []
     me = os.getpid()
     pids = []
@@ -3232,9 +3341,17 @@ def _capsule_build(name, kind, value, recipients, version, hive_id, signer):
     ct, tag = _chacha.encrypt(cek, nonce, value, aad)
     wraps = []
     for dev, cpub in sorted(recipients.items()):
-        eph = os.urandom(32)
-        eph_pub = _x25519.scalarmult_base(eph)
-        shared = _x25519.shared_secret(eph, cpub)                # raises on a low-order recipient key
+        # Per-recipient isolation: a single bad/low-order recipient key must NOT deny the secret to
+        # everyone else. Skip that recipient; the caller diffs `recipients` against the produced wraps
+        # to report which devices were unsealable (folded into the missing/suspect reporting).
+        try:
+            if not isinstance(cpub, (bytes, bytearray)) or len(cpub) != 32:
+                raise ValueError("recipient curve_pub is not 32 bytes")
+            eph = os.urandom(32)
+            eph_pub = _x25519.scalarmult_base(eph)
+            shared = _x25519.shared_secret(eph, cpub)            # raises on a low-order recipient key
+        except Exception:
+            continue
         wk = _hkdf_sha256(shared, eph_pub + cpub, b"hive-capsule-wrap", 32)
         wnonce = os.urandom(12)
         wct, wtag = _chacha.encrypt(wk, wnonce, cek, _CAPSULE_ALG.encode() + b"|wrap|" + eph_pub)
@@ -3268,13 +3385,15 @@ def _capsule_open(cap, my_scalar, my_device_id):
     try:
         cek = _chacha.decrypt(wk, wnonce, wct, wtag, _CAPSULE_ALG.encode() + b"|wrap|" + eph_pub)
     except ValueError:
-        raise ValueError("wrap auth failed (tampered or corrupt)")
+        raise ValueError("wrap auth failed (this capsule is tampered or corrupt) — re-sync from a "
+                         "healthy peer (`hv sync now`); if it persists, the owner should rotate it")
     nonce, ct, tag = (base64.b64decode(cap[k]) for k in ("nonce", "ct", "tag"))
     aad = f"{_CAPSULE_ALG}|{cap.get('hive_id','')}|{cap.get('name','')}|{cap.get('version',0)}".encode()
     try:
         return _chacha.decrypt(cek, nonce, ct, tag, aad)
     except ValueError:
-        raise ValueError("payload auth failed (tampered or corrupt)")
+        raise ValueError("payload auth failed (this capsule is tampered or corrupt) — re-sync from a "
+                         "healthy peer (`hv sync now`); if it persists, the owner should rotate it")
 
 
 def _read_secret_value(args, name):
@@ -3366,6 +3485,9 @@ def capsule_cmd(args):
         recips, missing, suspect = _recipient_pubkeys(entries, gov)
         if not recips:                                  # pre-owner / solo: seal to THIS device
             sc = _my_curve_scalar()
+            if sc is None and _ensure_device_key():     # fresh node: mint a key so solo capsules work
+                print(f"Minted this device's key (device_id: {NODE_ID}).")
+                sc = _my_curve_scalar()
             if sc is not None:
                 recips = {NODE_ID: _x25519.scalarmult_base(sc)}
         if not recips:
@@ -3383,9 +3505,16 @@ def capsule_cmd(args):
                 except Exception as e:
                     print(f"{nm}: cannot rotate (this device can't open it: {e})"); continue
                 nextv = int(cur.get("version", 0)) + 1
-                append_journal("capsule", _capsule_build(nm, cur.get("kind", "credential"), val,
-                                                         recips, nextv, gov.get("hive_id", ""), NODE_ID))
-                print(f"Rotated {nm!r} → v{nextv} ({len(recips)} recipient(s)).")
+                cap = _capsule_build(nm, cur.get("kind", "credential"), val,
+                                     recips, nextv, gov.get("hive_id", ""), NODE_ID)
+                append_journal("capsule", cap)
+                sealed = {w["device_id"] for w in cap.get("wraps", [])}
+                unsealable = sorted(set(recips) - sealed)
+                line = f"Rotated {nm!r} → v{nextv} ({len(sealed)} recipient(s))."
+                if unsealable:
+                    line += (f" SKIPPED {len(unsealable)} device(s) with an unusable key: "
+                             f"{', '.join(unsealable)}.")
+                print(line)
             print("Reminder: rotation does NOT revoke a removed device's access to OLD ciphertext it "
                   "already synced — rotate the upstream token to truly cut access.")
             return 0
@@ -3395,12 +3524,18 @@ def capsule_cmd(args):
             print("No value provided (cancelled)."); return 1
         cur = caps.get(args.name)
         nextv = (int(cur.get("version", 0)) + 1) if cur else 1
-        append_journal("capsule", _capsule_build(args.name, "credential", val, recips, nextv,
-                                                 gov.get("hive_id", ""), NODE_ID))
-        msg = f"Sealed capsule {args.name!r} v{nextv} to {len(recips)} device(s)."
+        cap = _capsule_build(args.name, "credential", val, recips, nextv,
+                             gov.get("hive_id", ""), NODE_ID)
+        append_journal("capsule", cap)
+        sealed = {w["device_id"] for w in cap.get("wraps", [])}
+        unsealable = sorted(set(recips) - sealed)
+        msg = f"Sealed capsule {args.name!r} v{nextv} to {len(sealed)} device(s)."
         if missing:
             msg += (f" WARNING: {len(missing)} admitted device(s) have no published pubkey yet and "
                     f"cannot open it until you rotate after they sync.")
+        if unsealable:
+            msg += (f" SKIPPED {len(unsealable)} device(s) with an unusable key (not sealed to): "
+                    f"{', '.join(unsealable)}.")
         if suspect:
             msg += (f" SECURITY: {len(suspect)} device(s) carried a curve_pub that disagrees with "
                     f"their identity-derived key — IGNORED (not trusted): {', '.join(sorted(suspect))}.")
@@ -3434,15 +3569,17 @@ def _leaky_key_files():
 
 
 def _fix_key_perms():
-    """Re-tighten any leaky secret key file to 0600. Returns the labels it fixed (for `--fix` output)."""
-    fixed = []
+    """Re-tighten any leaky secret key file to 0600. Returns (fixed, failed): a chmod that FAILS must
+    NOT be swallowed — a private key left group/other-readable collapses the whole threat model, so
+    the caller surfaces `failed` loudly rather than reporting a clean fix."""
+    fixed, failed = [], []
     for label, pth, _mode in _leaky_key_files():
         try:
             os.chmod(pth, 0o600)
             fixed.append(label)
-        except Exception:
-            pass
-    return fixed
+        except Exception as e:
+            failed.append(f"{label} ({e})")
+    return fixed, failed
 
 
 def _doctor_status():
@@ -3463,6 +3600,20 @@ def _doctor_status():
         checks.append({"name": "authenticity", "status": "ok" if v["ok"] else "fail", "detail": headline})
     except Exception as e:
         checks.append({"name": "authenticity", "status": "warn", "detail": f"check error: {e}"})
+
+    # 1a-bis. Crypto MODULE bindings — if hv's own _ed25519 import is None, `_verify_entry` falls
+    #     through to accepting EVERY entry unverified (the legacy grandfather path), i.e. signature
+    #     checking is silently OFF. That must be a loud HARD failure, not a hidden degradation.
+    _crypto_missing = [n for n, mod in (("ed25519", _ed25519), ("x25519", _x25519),
+                                        ("chacha20poly1305", _chacha)) if mod is None]
+    if "ed25519" in _crypto_missing:
+        checks.append({"name": "crypto-modules", "status": "fail",
+                       "detail": "ed25519 module unavailable — entry/governance signatures are NOT "
+                                 "being verified (all entries accepted unsigned). Reinstall/repair."})
+    elif _crypto_missing:
+        checks.append({"name": "crypto-modules", "status": "fail",
+                       "detail": f"crypto module(s) unavailable: {', '.join(_crypto_missing)} — "
+                                 f"capsules cannot be sealed/opened here. Reinstall/repair."})
 
     # 1b. Crypto self-test — known-answer tests for the bundled crypto (x25519/ed25519/ed↔curve +
     #     the capsule key-agreement), run on every doctor pass (and the 15-min `--fix` timer). A
@@ -3531,6 +3682,13 @@ def _doctor_status():
         else:
             checks.append({"name": "journal", "status": "ok",
                            "detail": f"{len(mine)} own entries chained from genesis, {len(entries)} total, root {root_hash[7:23]}"})
+        # Surface lines that read_all_entries silently dropped (truncated/garbled .jsonl) instead of
+        # letting that data loss pass unnoticed — advisory, since recovery is best-effort by design.
+        corrupt, where = merkle.corrupt_lines(JOURNAL_DIR)
+        if corrupt:
+            checks.append({"name": "journal-integrity", "status": "warn",
+                           "detail": f"{corrupt} unreadable/garbled journal line(s) skipped "
+                                     f"(in {', '.join(where)}) — possible truncated write; the rest is intact"})
     except Exception as e:
         checks.append({"name": "journal", "status": "fail", "detail": f"unreadable: {e}"})
 
@@ -3621,6 +3779,18 @@ def _doctor_status():
                                "detail": "all admitted devices have an identity-derived capsule key"})
         except Exception as e:
             checks.append({"name": "device-keys", "status": "warn", "detail": f"check error: {e}"})
+
+    # 3c. Capsule version conflicts — two devices sealed the same capsule version before syncing. The
+    #     projection resolves it deterministically, but one value silently lost; surface it (advisory).
+    try:
+        conflicts = _capsule_version_conflicts(entries)
+        if conflicts:
+            checks.append({"name": "capsule-conflicts", "status": "warn",
+                           "detail": f"{len(conflicts)} capsule(s) had a concurrent same-version seal "
+                                     f"(one writer's value lost the deterministic tie): {', '.join(conflicts)}"
+                                     f" — re-`hv capsule put` the intended value to supersede"})
+    except Exception:
+        pass
 
     # 4. Hygiene — duplicates / obsolete / re-check, as surfaced by the audit. Advisory only.
     try:
@@ -3777,14 +3947,31 @@ def doctor_cmd(args):
             print("\nall checks passed.")
 
     if getattr(args, "fix", False):
+        # --dry-run previews EVERY mutating action (chmod, kill-by-cmdline, systemd restart, foreign
+        # Claude-config rewrite) without performing it — so an operator can see the blast radius of
+        # doctor's broad self-heal before letting it touch processes or another tool's config.
+        dry = getattr(args, "dry_run", False)
+        if dry:
+            print("\n--fix --dry-run: PREVIEW only — nothing below will actually be changed.")
         if os.name != "nt":
-            fixed = _fix_key_perms()
-            if fixed:
-                print(f"\n--fix: re-tightened {', '.join(fixed)} to 0600.")
+            if dry:
+                leaky = _leaky_key_files()
+                if leaky:
+                    print(f"  would re-tighten to 0600: {', '.join(lbl for lbl, _p, _m in leaky)}")
+            else:
+                fixed, failed = _fix_key_perms()
+                if fixed:
+                    print(f"\n--fix: re-tightened {', '.join(fixed)} to 0600.")
+                if failed:
+                    print(f"\n--fix: FAILED to tighten {', '.join(failed)} — these private key(s) are "
+                          f"STILL group/other-readable; fix manually (`chmod 600`) NOW.")
 
         orphans = [p for c in checks for p in (c.get("orphans") or [])]
         if not orphans:
             print("\n--fix: no orphan daemons to clear.")
+        elif dry:
+            print(f"\n  would kill {len(orphans)} orphan daemon(s): {', '.join(map(str, orphans))}"
+                  f" and restart the systemd hive-sync unit (if present)")
         else:
             print(f"\n--fix: killing {len(orphans)} orphan daemon(s): {', '.join(map(str, orphans))}")
             _kill_orphans(orphans)
@@ -3801,8 +3988,18 @@ def doctor_cmd(args):
         # re-asserted with no one re-running the installer — the self-heal promise, extended to the
         # one component that lives outside the daemon's control.
         try:
-            w = _wire_claude_hooks(write=True)
-            if not w["applicable"]:
+            w = _wire_claude_hooks(write=not dry)   # dry-run → preview the diff without writing config
+            if dry:
+                if w["applicable"] and (w["missing"] or w["stale"] or not w["skill_ok"]):
+                    acts = []
+                    if w["missing"]:
+                        acts.append(f"wire {len(w['missing'])} dispatch shim(s)")
+                    if w["stale"]:
+                        acts.append(f"migrate {len(w['stale'])} legacy hook(s) to the shim")
+                    if not w["skill_ok"]:
+                        acts.append("relink the hive-memory skill")
+                    print("\n  would rewrite ~/.claude/settings.json to: " + "; ".join(acts) + ".")
+            elif not w["applicable"]:
                 pass  # no Claude Code on this node — nothing to wire
             elif w["wrote"] or w["skill_fixed"]:
                 acts = []
@@ -4466,7 +4663,8 @@ def discover_cmd(args):
     candidates = [(ip, p) for ip in ips for p in range(port, port + 5)]
     found = {}
     if candidates:
-        print(f"  probing {len(ips)} tailnet device(s)…", file=sys.stderr)
+        if getattr(args, "format", "text") != "json":   # keep --format json clean for scripts
+            print(f"  probing {len(ips)} tailnet device(s)…", file=sys.stderr)
         with concurrent.futures.ThreadPoolExecutor(max_workers=min(32, len(candidates))) as ex:
             for ip, p, info in ex.map(lambda c: (c[0], c[1], _probe_hive(c[0], c[1], timeout=3)), candidates):
                 if info and info["hive_id"] not in found:
@@ -4494,6 +4692,8 @@ def join_cmd(args):
     Non-blocking — you're already syncing the hive; your writes simply do not count toward
     confidence until the owner admits you. The request is device-signed (not owner-signed), so it
     carries no authority — it's only a visible, pending ask."""
+    if _ensure_device_key():
+        print(f"Minted this device's key first (device_id: {NODE_ID}) — needed to join and receive capsules.")
     entries = merkle.read_all_entries(JOURNAL_DIR)
     gov = _governance_state(entries)
     if not gov["owner_id"]:
@@ -4913,6 +5113,8 @@ def build_parser():
     doctor_parser.add_argument("--format", choices=["text", "json"], default="text")
     doctor_parser.add_argument("--fix", action="store_true",
                                help="Take safe remedial action: kill orphan sync daemons + restart the managed unit, and re-assert the Claude Code hooks/skill")
+    doctor_parser.add_argument("--dry-run", action="store_true",
+                               help="With --fix: PREVIEW the remedial actions (kill/restart/rewire) without making any change")
     doctor_sub = doctor_parser.add_subparsers(dest="doctor_action")
     doctor_sub.add_parser("merkle", help="Show the Merkle index over the journal (sync diagnostic)")
     doctor_mig = doctor_sub.add_parser("migrate-identity",

--- a/merkle.py
+++ b/merkle.py
@@ -59,6 +59,36 @@ def read_all_entries(journal_dir):
     return entries
 
 
+def corrupt_lines(journal_dir):
+    """Count (and sample the files of) non-empty journal lines that read_all_entries SILENTLY skips —
+    unparseable JSON or entries missing node_id/seq (e.g. a truncated/garbled .jsonl from a crash mid-
+    write). Surfaced by `hv doctor` so silent data loss becomes visible. Returns (count, [filenames])."""
+    journal_dir = Path(journal_dir)
+    if not journal_dir.exists():
+        return 0, []
+    count, sample = 0, []
+
+    def _flag(name):
+        nonlocal count
+        count += 1
+        if name not in sample and len(sample) < 5:
+            sample.append(name)
+
+    for f in sorted(journal_dir.glob("*.jsonl")):
+        for line in f.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                _flag(f.name)
+                continue
+            if not isinstance(e, dict) or "node_id" not in e or "seq" not in e:
+                _flag(f.name)
+    return count, sample
+
+
 def chunk_hashes(entries, size=CHUNK_SIZE):
     """SHA-256 over each contiguous chunk of `size` entries (canonical bytes)."""
     hashes = []

--- a/sync_daemon.py
+++ b/sync_daemon.py
@@ -33,6 +33,46 @@ PROTOCOL_VERSION = 1
 # outbound sync (M5) don't rebuild SQLite concurrently.
 _ingest_lock = threading.Lock()
 
+# ── DoS / abuse hardening ────────────────────────────────────────────────────────────────────
+# The tailnet (Tailscale) is the trust perimeter, but a SINGLE misbehaving/compromised peer must
+# not be able to OOM the node (huge body), thread-exhaust it (connection flood), wedge it (slow
+# read), or flood it (request storm). These guards are best-effort and NOT consensus-bearing.
+MAX_BODY_BYTES = 32 * 1024 * 1024          # reject /sync/ingest bodies larger than this (413)
+SOCKET_TIMEOUT = 30                        # per-connection read timeout, seconds (slow-loris guard)
+MAX_CONCURRENT_REQUESTS = 32               # in-flight handlers; excess → 503 (thread-exhaustion guard)
+RATE_BUCKET_CAPACITY = 256                 # per-peer token bucket burst (generous: a full chunked
+RATE_REFILL_PER_SEC = 64                   #   sync is bursty — these throttle abuse, not real sync)
+
+_request_slots = threading.BoundedSemaphore(MAX_CONCURRENT_REQUESTS)
+
+
+class _RateLimiter:
+    """Best-effort in-memory token bucket per peer-IP. Blunts a chatty/abusive peer without
+    throttling a legitimate (bursty) sync. Buckets are pruned lazily so the map stays bounded."""
+
+    def __init__(self, capacity, refill_per_sec):
+        self.capacity = float(capacity)
+        self.refill = float(refill_per_sec)
+        self._buckets = {}                 # ip -> (tokens, last_monotonic)
+        self._lock = threading.Lock()
+
+    def allow(self, ip):
+        now = time.monotonic()
+        with self._lock:
+            tokens, last = self._buckets.get(ip, (self.capacity, now))
+            tokens = min(self.capacity, tokens + (now - last) * self.refill)
+            if tokens < 1.0:
+                self._buckets[ip] = (tokens, now)
+                return False
+            self._buckets[ip] = (tokens - 1.0, now)
+            if len(self._buckets) > 4096:  # lazy prune: drop buckets idle > 1h
+                self._buckets = {k: (t, ts) for k, (t, ts) in self._buckets.items()
+                                 if ts >= now - 3600}
+            return True
+
+
+_rate_limiter = _RateLimiter(RATE_BUCKET_CAPACITY, RATE_REFILL_PER_SEC)
+
 
 def _entries():
     return merkle.read_all_entries(hv.JOURNAL_DIR)
@@ -40,6 +80,14 @@ def _entries():
 
 class Handler(BaseHTTPRequestHandler):
     server_version = "hive-sync/2.0"
+    timeout = SOCKET_TIMEOUT             # honored by socketserver setup() → socket read timeout
+
+    def setup(self):
+        super().setup()
+        try:                             # belt-and-suspenders: bound slow reads even if `timeout` is ignored
+            self.connection.settimeout(SOCKET_TIMEOUT)
+        except Exception:
+            pass
 
     def log_message(self, fmt, *args):  # keep the daemon quiet; errors go to do_*
         pass
@@ -52,7 +100,27 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _enter(self):
+        """Rate-limit + concurrency gate. Returns True if the request may proceed (caller MUST then
+        call _leave() in a finally); otherwise sends 429/503 and returns False."""
+        ip = self.client_address[0] if self.client_address else "?"
+        if not _rate_limiter.allow(ip):
+            self._send(429, {"error": "rate limited"})
+            return False
+        if not _request_slots.acquire(blocking=False):
+            self._send(503, {"error": "server busy"})
+            return False
+        return True
+
+    def _leave(self):
+        try:
+            _request_slots.release()
+        except Exception:
+            pass
+
     def do_GET(self):
+        if not self._enter():
+            return
         u = urlparse(self.path)
         q = parse_qs(u.query)
         try:
@@ -91,15 +159,28 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(404, {"error": "not found"})
         except Exception as e:  # never crash the handler thread
             self._send(500, {"error": str(e)})
+        finally:
+            self._leave()
 
     def do_POST(self):
-        u = urlparse(self.path)
-        if u.path != "/sync/ingest":
-            self._send(404, {"error": "not found"})
+        if not self._enter():
             return
         try:
-            length = int(self.headers.get("Content-Length", 0))
-            body = json.loads(self.rfile.read(length) or b"{}")
+            u = urlparse(self.path)
+            if u.path != "/sync/ingest":
+                self._send(404, {"error": "not found"})
+                return
+            # Bound the request body BEFORE reading it: a missing/garbage Content-Length is a 400,
+            # an over-cap one is a 413 — so no peer can stream an unbounded body into memory.
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+            except (TypeError, ValueError):
+                self._send(400, {"error": "bad Content-Length"})
+                return
+            if length < 0 or length > MAX_BODY_BYTES:
+                self._send(413, {"error": "request too large", "max_bytes": MAX_BODY_BYTES})
+                return
+            body = json.loads((self.rfile.read(length) if length else b"{}") or b"{}")
             # Refuse a cross-hive push: if both sides have a hive_id and they differ, this is a
             # different hive's journal and must not merge into ours.
             local_hive, sender_hive = hv._local_hive_id(), body.get("hive_id", "")
@@ -114,6 +195,8 @@ class Handler(BaseHTTPRequestHandler):
             self._send(200, {"accepted": accepted, "duplicates": duplicates})
         except Exception as e:
             self._send(500, {"error": str(e)})
+        finally:
+            self._leave()
 
 
 class AlreadyRunning(Exception):

--- a/tests/test_hardening_batch2.py
+++ b/tests/test_hardening_batch2.py
@@ -1,0 +1,227 @@
+"""Security hardening batch 2 — DoS limits, journal-append atomicity, capsule per-recipient
+tolerance, governance memoization, election clock-skew bound, auto device-key, and the new
+visibility helpers. Fast unit tests (direct module load) plus one loopback daemon integration."""
+
+import base64
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+PROJECT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT))
+import x25519        # noqa: E402
+import ed25519       # noqa: E402
+import merkle        # noqa: E402
+
+
+def _load(name, home, monkeypatch, **env):
+    """Load a fresh copy of `name` ('hv' or 'sync_daemon') with HIVE_HOME (+ extra env) set first —
+    NODE_ID / DEVICE_KEY_PATH are resolved at import, so env must be in place before exec."""
+    monkeypatch.setenv("HIVE_HOME", str(home))
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    path = str(PROJECT / ("hv" if name == "hv" else f"{name}.py"))
+    loader = importlib.machinery.SourceFileLoader(f"{name}_b2_{home.name}", path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    m = importlib.util.module_from_spec(spec)
+    loader.exec_module(m)
+    return m
+
+
+# ── P1-6: rate limiter ────────────────────────────────────────────────────────────────────────
+def test_rate_limiter_burst_then_deny(tmp_path, monkeypatch):
+    sd = _load("sync_daemon", tmp_path, monkeypatch)
+    rl = sd._RateLimiter(capacity=3, refill_per_sec=0)   # no refill → deterministic burst test
+    assert [rl.allow("1.2.3.4") for _ in range(3)] == [True, True, True]
+    assert rl.allow("1.2.3.4") is False                  # bucket drained
+    assert rl.allow("9.9.9.9") is True                   # a different peer has its own bucket
+
+
+# ── P0-1: sync daemon body-size cap (loopback integration) ──────────────────────────────────────
+def _free_port():
+    import socket
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
+    return port
+
+
+def test_oversized_post_rejected_413(tmp_path, monkeypatch):
+    sd = _load("sync_daemon", tmp_path, monkeypatch)
+    monkeypatch.setattr(sd, "MAX_BODY_BYTES", 100)       # shrink the cap so the test body is tiny
+    server, _bind, port = sd.make_server(bind="127.0.0.1", port=_free_port())
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        body = json.dumps({"entries": ["x" * 500]}).encode()   # > 100 bytes
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/sync/ingest", data=body,
+                                     headers={"Content-Type": "application/json"}, method="POST")
+        code = None
+        try:
+            urllib.request.urlopen(req, timeout=5)
+        except urllib.error.HTTPError as e:
+            code = e.code
+        assert code == 413, f"expected 413 for oversized body, got {code}"
+    finally:
+        server.shutdown()
+
+
+# ── P0-2: journal append atomicity under concurrency ────────────────────────────────────────────
+def test_append_line_no_interleave_under_concurrency(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch)
+    target = tmp_path / "journal" / "concurrent.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    THREADS, PER = 16, 40
+    big = "P" * 8000                                      # > PIPE_BUF (4096): O_APPEND alone could tear
+
+    def writer(tid):
+        for i in range(PER):
+            hv._append_line(target, json.dumps({"t": tid, "i": i, "pad": big}))
+
+    ts = [threading.Thread(target=writer, args=(n,)) for n in range(THREADS)]
+    [t.start() for t in ts]
+    [t.join() for t in ts]
+    lines = [ln for ln in target.read_text().splitlines() if ln.strip()]
+    assert len(lines) == THREADS * PER
+    for ln in lines:
+        json.loads(ln)                                   # every line is intact JSON — no interleave
+
+
+# ── P0-3: capsule build tolerates a bad recipient ──────────────────────────────────────────────
+def test_capsule_build_skips_bad_recipient(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch)
+    seed = os.urandom(32)
+    good_cp = x25519.ed_pub_to_curve_pub(ed25519.pub_from_seed(seed))
+    good_scalar = x25519.ed_seed_to_curve_scalar(seed)
+    recipients = {
+        "k1:good": good_cp,
+        "k1:wronglen": b"\x00" * 31,                     # not 32 bytes → skipped
+        "k1:loworder": b"\x00" * 32,                     # degenerate shared secret → skipped
+    }
+    cap = hv._capsule_build("TOK", "credential", b"s3cret", recipients, 1, "h1:x", "k1:good")
+    sealed = {w["device_id"] for w in cap["wraps"]}
+    assert sealed == {"k1:good"}                         # only the valid recipient got a wrap
+    assert hv._capsule_open(cap, good_scalar, "k1:good") == b"s3cret"
+
+
+# ── P1-1: governance memoization is transparent ─────────────────────────────────────────────────
+def _owner_corpus(hv, n_admit=2):
+    seed = os.urandom(32)
+    pub = ed25519.pub_from_seed(seed)
+    oid = hv._owner_id_for_pub(pub)
+
+    def govent(payload, seq, ts):
+        p = hv._sign_governance_payload(payload, seed, pub)
+        return {"node_id": "n", "seq": seq, "type": "governance", "timestamp": ts,
+                "payload": p, "prev_hash": "sha256:genesis"}
+
+    entries = [govent({"action": "owner", "owner_id": oid,
+                       "owner_pub": base64.b64encode(pub).decode(), "hive_id": "h1:abc"},
+                      1, "2026-01-01T00:00:00Z")]
+    for i in range(n_admit):
+        entries.append(govent({"action": "admit", "device_id": f"k1:dev{i}"}, 2 + i,
+                               f"2026-01-0{2+i}T00:00:00Z"))
+    return seed, pub, oid, entries, govent
+
+
+def test_governance_memo_matches_uncached_and_invalidates(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch)
+    _seed, _pub, _oid, entries, govent = _owner_corpus(hv)
+    assert hv._governance_state(entries) == hv._governance_state_uncached(entries)   # byte-identical
+    # mutating the returned copy must NOT corrupt the cache
+    g = hv._governance_state(entries)
+    g["admitted"].add("k1:injected")
+    assert "k1:injected" not in hv._governance_state(entries)["admitted"]
+    # a new governance entry busts the cache → new admitted set
+    before = hv._governance_state(entries)["admitted"]
+    entries.append(govent({"action": "admit", "device_id": "k1:late"}, 99, "2026-02-01T00:00:00Z"))
+    after = hv._governance_state(entries)["admitted"]
+    assert "k1:late" in after and "k1:late" not in before
+
+
+# ── P1-2: election clock-skew bound (deterministic) ─────────────────────────────────────────────
+def _election_corpus(hv, basis_ts, entry_ts):
+    """owner + quorum_m=1 + an admitted voter that proposes an election with the given basis_ts on an
+    entry stamped entry_ts. Returns the full entries list."""
+    oseed = os.urandom(32); opub = ed25519.pub_from_seed(oseed); oid = hv._owner_id_for_pub(opub)
+    vseed = os.urandom(32); vpub = ed25519.pub_from_seed(vseed); vid = hv._device_id_for_pub(vpub)
+    nseed = os.urandom(32); npub_b64 = base64.b64encode(ed25519.pub_from_seed(nseed)).decode()
+
+    def owner_ent(payload, seq, ts):
+        return {"node_id": "owner", "seq": seq, "type": "governance", "timestamp": ts,
+                "payload": hv._sign_governance_payload(payload, oseed, opub), "prev_hash": "sha256:genesis"}
+
+    entries = [
+        owner_ent({"action": "owner", "owner_id": oid, "owner_pub": base64.b64encode(opub).decode(),
+                   "hive_id": "h1:abc"}, 1, "2026-01-01T00:00:00Z"),
+        owner_ent({"action": "set-config", "key": "quorum_m", "value": 1}, 2, "2026-01-01T00:00:01Z"),
+        owner_ent({"action": "admit", "device_id": vid}, 3, "2026-01-01T00:00:02Z"),
+    ]
+    pid = hv._election_id(npub_b64, basis_ts)
+    prop = {"node_id": vid, "seq": 1, "type": "governance", "timestamp": entry_ts,
+            "payload": {"action": "propose-election", "proposal_id": pid,
+                        "new_owner_pub": npub_b64, "basis_ts": basis_ts}, "prev_hash": "sha256:genesis"}
+    hv._sign_entry(prop, vseed, vpub)                    # device-signed (projection requires it)
+    entries.append(prop)
+    return entries
+
+
+def test_future_dated_basis_ts_is_rejected(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch)
+    # basis_ts far in the future relative to the proposal's OWN entry timestamp → dropped
+    future = hv._governance_state(_election_corpus(hv, basis_ts="2099-01-01T00:00:00Z",
+                                                   entry_ts="2026-03-01T00:00:00Z"))
+    assert future["elections"] == []
+    # basis_ts == entry timestamp (legitimate) → the proposal is counted
+    normal = hv._governance_state(_election_corpus(hv, basis_ts="2026-03-01T00:00:00Z",
+                                                   entry_ts="2026-03-01T00:00:00Z"))
+    assert len(normal["elections"]) == 1
+
+
+# ── P1-4: auto-mint device key ──────────────────────────────────────────────────────────────────
+def test_ensure_device_key_mints_on_fresh_node(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch)
+    assert hv._device_seed() is None
+    assert hv._ensure_device_key() is True               # fresh, empty → mints
+    assert hv._device_seed() is not None
+    assert hv.NODE_ID.startswith("k1:")
+    assert hv._ensure_device_key() is False              # idempotent: already has a key
+
+
+def test_ensure_device_key_respects_node_id_override(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch, HIVE_NODE_ID="forced-id")
+    assert hv._ensure_device_key() is False              # override present → never auto-mints
+    assert hv._device_seed() is None
+
+
+# ── P2-1 / P2-3: visibility helpers ─────────────────────────────────────────────────────────────
+def test_capsule_version_conflicts_detected(tmp_path, monkeypatch):
+    hv = _load("hv", tmp_path, monkeypatch)
+
+    def cap_ent(node, name, ver):
+        return {"node_id": node, "seq": ver, "type": "capsule",
+                "payload": {"name": name, "version": ver}}
+    # same (name, version) from two devices = conflict; same device = not
+    entries = [cap_ent("k1:a", "TOK", 2), cap_ent("k1:b", "TOK", 2),
+               cap_ent("k1:a", "OTHER", 1), cap_ent("k1:a", "OTHER", 2)]
+    assert hv._capsule_version_conflicts(entries) == ["TOK"]
+
+
+def test_merkle_corrupt_lines_counts_skipped(tmp_path):
+    jdir = tmp_path / "journal"
+    jdir.mkdir()
+    f = jdir / "2026-01-01.jsonl"
+    f.write_text(
+        json.dumps({"node_id": "n", "seq": 1, "type": "fact", "payload": {}}) + "\n"
+        + "{not json at all\n"                            # unparseable
+        + json.dumps({"type": "fact"}) + "\n"            # missing node_id/seq
+    )
+    count, where = merkle.corrupt_lines(jdir)
+    assert count == 2 and "2026-01-01.jsonl" in where
+    assert len(merkle.read_all_entries(jdir)) == 1       # the good line still loads


### PR DESCRIPTION
Second hardening pass over the manual security review. Closes the highest-impact soft spots within the stated threat model (0600 local keys + signed append-only journal + Tailscale-trusted network). The two consensus-critical ingest changes (bootstrap/TOFU, join-replay) are **documented** in `docs/THREAT_MODEL.md`, not changed, to avoid risking cross-node journal divergence.

## P0 — must-fix before wider use
- **Sync daemon DoS hardening** (`sync_daemon.py`): 413 over `MAX_BODY_BYTES` before reading the body, per-connection read timeout (slow-loris), bounded concurrent handlers via semaphore (503 when saturated). One misbehaving tailnet peer can no longer OOM/wedge/thread-exhaust a node.
- **Journal append atomicity** (`hv`): `_append_line` takes an exclusive `fcntl.flock` so a daemon+CLI write can't interleave mid-line and corrupt a daily `.jsonl` (records exceed PIPE_BUF, so O_APPEND alone isn't atomic). Both `append_journal` and foreign-ingest `_persist` route through it.
- **Per-recipient capsule tolerance** (`hv`): `_capsule_build` skips a bad/low-order recipient key instead of aborting the whole seal; put/rotate report skipped devices (`unsealable`) next to missing/suspect.

## P1
- **Memoize `_governance_state`** on a content signature of just the governance entries — a ~6s pure-Python-verify projection becomes a 0.06ms cache hit, and a plain `fact` write doesn't bust it. Returns a deep copy (cache can't be corrupted); output byte-identical to the uncached projection.
- **Deterministic election clock-skew bound**: reject a proposal whose `basis_ts` leads its own entry timestamp beyond a small allowance, so a future-dated `basis_ts` can't retroactively arm the dead-man switch. Entry-time vs entry-time only (no wall-clock) → journal stays convergent.
- **Auto-mint the device key** on a fresh node (join + solo capsule put); never splits identity (refuses on `HIVE_NODE_ID` override or a populated hostname journal).
- **Tighten security-sensitive excepts**: chmod-failure in key-perm fix → loud doctor failure (not a silent "fixed"); pgrep-failure surfaced; missing ed25519 module → hard `crypto-modules` doctor failure (it silently disables signature verification otherwise).
- **Per-peer token-bucket rate limiting** (429), generous enough not to throttle a real chunked sync.

## P2
- `doctor --fix --dry-run` previews every mutating action (kill-by-cmdline, systemd restart, foreign Claude-config rewrite) without doing them.
- doctor surfaces capsule version conflicts and skipped/garbled journal lines.
- Capsule AEAD-failure messages guide to re-sync/rotate; quieter `discover`.

## Docs & tests
- New `docs/THREAT_MODEL.md`: trust assumptions, misbehaving-peer + local-race adversary, pure-Python non-constant-time posture (timing side-channels out of scope under the model), bootstrap/TOFU + join-replay documented limitations, journal-growth notes.
- New `tests/test_hardening_batch2.py` (10 tests). **Full suite: 201 passed**; crypto self-test green; manual smoke confirms auto-mint, doctor checks, and dry-run.

Builds on PR #11 (recipient-key proof-of-possession).

🤖 Generated with [Claude Code](https://claude.com/claude-code)