### PR TITLE
feat(macos): add macOS support via launchd supervisor seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -16,3 +20,42 @@ jobs:
         run: pip install -r requirements.txt pytest
       - name: Run offline test suite
         run: python3 -m pytest -q
+
+  # macOS-only: exercise the installer/launchd path as far as an ephemeral, headless
+  # runner allows. Branch protection requires no check, so a soft step here never blocks
+  # merges. What it CANNOT prove (needs a real Mac): that `launchctl bootstrap gui/$UID`
+  # actually loads under a login session, reboot persistence, and real Tailscale auth.
+  macos-installer-smoke:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: dispatcher resolves through a symlink (readlink -f shim)
+        run: |
+          ln -s "$PWD/scripts/installer/dispatcher.sh" /tmp/hive-mind
+          /tmp/hive-mind help | grep -q 'Subcommands'
+      - name: launchd plists render + plutil -lint
+        run: bash scripts/installer/_launchd.sh --render-test
+      - name: sync daemon answers on :9876 natively
+        run: |
+          HIVE_HOME="$PWD" python3 ./hv rebuild >/dev/null 2>&1 || true
+          HIVE_HOME="$PWD" nohup python3 sync_daemon.py >/tmp/d.log 2>&1 &
+          ok=
+          for i in $(seq 1 20); do
+            curl -sf http://127.0.0.1:9876/sync/hello >/dev/null && { ok=1; break; }
+            sleep 1
+          done
+          [ -n "$ok" ] || { echo "daemon did not answer on :9876"; cat /tmp/d.log; exit 1; }
+          echo "daemon answered /sync/hello"
+      - name: launchctl bootstrap (best-effort; GUI domain may be absent in headless CI)
+        continue-on-error: true
+        run: |
+          bash -c '. scripts/installer/_service.sh; service_install "$PWD" hive-sync'
+          launchctl print "gui/$(id -u)/com.projectmentor.hive-sync" \
+            || echo "gui domain unavailable in headless CI — bootstrap unverifiable here (needs a real Mac)"
+      - name: service uninstall is idempotent
+        run: bash -c '. scripts/installer/_service.sh; launchd_uninstall hive-sync; launchd_uninstall hive-sync'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ apart from Pinecone, Weaviate, LlamaIndex, LangGraph, and friends.
 
 ## Install
 
-On Linux (or a WSL terminal on Windows 11), run:
+On macOS, Linux, or a WSL terminal on Windows 11, run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/projectmentor/hive-mind/main/scripts/installer/install.sh | bash
@@ -69,17 +69,19 @@ The installer will:
 4. Ask for one input: your peer's Tailscale IP. **First machine with no peers yet? Just press
    Enter** — you can add peers later by editing `.peers.json`.
 5. Initialise the local database
-6. Install and start the sync daemon as a systemd service
+6. Install and start the sync daemon under your OS's service manager (systemd on Linux/WSL,
+   launchd on macOS)
 7. Wire the Hermes memory plugin (if Hermes is installed)
 
 ### Requirements
 
-- **Linux** (native) or **Windows 11 with WSL2**, with systemd enabled (Mac and Android
-  support are in progress)
+- **macOS**, **Linux** (native), or **Windows 11 with WSL2** (with systemd enabled). Android
+  support is in progress. On macOS the daemon runs as a launchd LaunchAgent.
 - **Internet access** (for the install and git clone)
 - **Tailscale** *only if you want multiple machines to sync.* The installer sets it up for
-  you (inside WSL on Windows; it is **not** needed on the Windows host). A single-machine
-  setup needs no Tailscale at all — there are no peers to reach.
+  you (inside WSL on Windows; on macOS install the app or `brew install tailscale`; it is
+  **not** needed on the Windows host). A single-machine setup needs no Tailscale at all —
+  there are no peers to reach.
 
 <details>
 <summary>Enable systemd in WSL (if it isn't already)</summary>
@@ -196,7 +198,7 @@ the policy and the common failure modes.
 
 - **Federated hives (a colony)** — separate hives (personal, team, project) that selectively share
   what matters, so groups pool knowledge without merging into one pool. Multiple hives form a colony.
-- **More platforms** — Mac and Android.
+- **More platforms** — Android (macOS, Linux, and WSL2 are supported today).
 - **Hosted relay** — an optional managed tier for nodes that can't reach each other directly.
 
 ---

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -778,13 +778,16 @@ This file is not synced to git — it's specific to each machine.
 ./hv sync daemon
 
 # Check background service status
-systemctl --user status hive-sync
+systemctl --user status hive-sync                          # Linux / WSL
+launchctl print gui/$(id -u)/com.projectmentor.hive-sync   # macOS
 
 # Watch sync logs live
-journalctl --user -u hive-sync -f
+journalctl --user -u hive-sync -f                          # Linux / WSL
+tail -f ~/Library/Logs/hive-mind/hive-sync.log             # macOS
 
 # Restart the background service (e.g. after editing peers.json)
-systemctl --user restart hive-sync
+systemctl --user restart hive-sync                                   # Linux / WSL
+launchctl kickstart -k gui/$(id -u)/com.projectmentor.hive-sync      # macOS
 ```
 
 ---

--- a/docs/SYNC_API.md
+++ b/docs/SYNC_API.md
@@ -359,6 +359,12 @@ as a separate machine on the tailnet, e.g. `node-a-1`). The sync daemon
 binds `0.0.0.0:9876` and is reachable directly at the WSL Tailscale IP. No
 portproxy or mirrored networking needed. Get the WSL IP with `tailscale ip`.
 
+**macOS note:** Install Tailscale via the app (App Store / standalone) or
+`brew install tailscale`; the app or `brew services` owns `tailscaled` (the
+installer never `sudo systemctl`-starts it on macOS). The daemon runs as a
+launchd LaunchAgent (`com.projectmentor.hive-sync`), logging to
+`~/Library/Logs/hive-mind/`. Get the node's IP with `tailscale ip`.
+
 ---
 
 ## Error Responses

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -86,5 +86,6 @@ at once). Concretely:
 - **Best-effort recovery.** A truncated/garbled journal line (e.g. a crash mid-write) is skipped on
   read; `hv doctor` now surfaces the count so silent data loss is visible (`journal-integrity`).
 - **`hv doctor --fix` blast radius.** `--fix` kills orphan daemons (by argv match), restarts the
-  managed systemd unit, and rewrites the foreign Claude Code config (with a backup). Run
+  managed daemon (systemd unit on Linux/WSL, launchd agent on macOS), and rewrites the foreign
+  Claude Code config (with a backup). Run
   `hv doctor --fix --dry-run` to preview every mutating action before letting it run.

--- a/hv
+++ b/hv
@@ -2852,6 +2852,23 @@ def _systemd_hive_sync():
         return False, None
 
 
+def _launchd_hive_sync():
+    """(loaded, None) for the macOS launchd hive-sync agent in the per-user GUI domain;
+    (False, None) off-darwin or when launchctl can't see it. The macOS analogue of
+    _systemd_hive_sync — lets `hv doctor --fix` restart a crashed launchd-managed daemon
+    (orphan DETECTION already works cross-platform via _classify_orphans; only the restart
+    ACTION needs this sibling). No MainPID equivalent is needed at the restart site."""
+    if sys.platform != "darwin":
+        return False, None
+    try:
+        r = subprocess.run(
+            ["launchctl", "print", f"gui/{os.getuid()}/com.projectmentor.hive-sync"],
+            capture_output=True, text=True, timeout=5)
+        return (r.returncode == 0), None
+    except Exception:
+        return False, None
+
+
 def _classify_orphans(pids, main_pid, unit_exists):
     """Which daemon PIDs are orphans, i.e. NOT the one systemd is supposed to manage. Pure (testable).
     - managed daemon present: any OTHER daemon process is an orphan (a second one outside systemd).
@@ -3971,15 +3988,25 @@ def doctor_cmd(args):
             print("\n--fix: no orphan daemons to clear.")
         elif dry:
             print(f"\n  would kill {len(orphans)} orphan daemon(s): {', '.join(map(str, orphans))}"
-                  f" and restart the systemd hive-sync unit (if present)")
+                  f" and restart the managed hive-sync service (if present)")
         else:
             print(f"\n--fix: killing {len(orphans)} orphan daemon(s): {', '.join(map(str, orphans))}")
             _kill_orphans(orphans)
-            unit_exists, _ = _systemd_hive_sync()
-            if unit_exists:
-                subprocess.run(["systemctl", "--user", "restart", "hive-sync"], capture_output=True)
-                time.sleep(2)
-                print("  restarted the systemd hive-sync unit.")
+            # Restart the supervisor-managed daemon so the just-cleared port is reclaimed by the
+            # canonical instance: systemd on Linux/WSL, launchd on macOS.
+            if sys.platform == "darwin":
+                if _launchd_hive_sync()[0]:
+                    subprocess.run(["launchctl", "kickstart", "-k",
+                                    f"gui/{os.getuid()}/com.projectmentor.hive-sync"],
+                                   capture_output=True)
+                    time.sleep(2)
+                    print("  restarted the launchd hive-sync agent.")
+            else:
+                unit_exists, _ = _systemd_hive_sync()
+                if unit_exists:
+                    subprocess.run(["systemctl", "--user", "restart", "hive-sync"], capture_output=True)
+                    time.sleep(2)
+                    print("  restarted the systemd hive-sync unit.")
             after = next((c for c in _doctor_status() if c["name"] == "sync-daemon"), None)
             print(f"  sync-daemon now: {after['detail'] if after else 'unknown'}")
 

--- a/scripts/installer/_install_node.sh
+++ b/scripts/installer/_install_node.sh
@@ -37,9 +37,11 @@ TOTAL=13
 # (A child process can't reload the parent shell; the hint only matters when it's absent.)
 case ":$PATH:" in *":$HOME/.local/bin:"*) BIN_ON_PATH=1 ;; *) BIN_ON_PATH="" ;; esac
 
-# Shared systemd-unit writer (single source of truth, also used by `hive-mind update`).
-_UNITLIB="$HIVE_DIR/scripts/installer/_units.sh"
-[ -f "$_UNITLIB" ] && . "$_UNITLIB"
+# Cross-platform supervisor seam: systemd units on Linux/WSL, launchd on macOS.
+# Sources _units.sh (the systemd writer) and, on macOS, _launchd.sh — and exposes
+# service_install / service_restart / service_is_active + the launchd_* backend.
+_SVCLIB="$HIVE_DIR/scripts/installer/_service.sh"
+if [ -f "$_SVCLIB" ]; then . "$_SVCLIB"; fi
 
 # ── colours ────────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GRN='\033[0;32m'; YLW='\033[1;33m'; CYN='\033[0;36m'; BLD='\033[1m'; RST='\033[0m'
@@ -61,17 +63,21 @@ echo ""
 # ════════════════════════════════════════════════════════════════════════════
 step "1/$TOTAL  Pre-flight checks"
 
-# HiveMind runs on Linux. WSL2 is a Linux kernel, so native Linux works the same;
-# we only branch on the handful of Windows-interop steps below (gated on IS_WSL).
-if [ "$(uname -s)" != "Linux" ]; then
-  die "HiveMind installs on Linux (native, or WSL2 on Windows 11). This system is not Linux."
-fi
-IS_WSL=""
-grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && IS_WSL=1
+# HiveMind runs on Linux (native or WSL2) and macOS. WSL2 is a Linux kernel, so
+# native Linux works the same; macOS uses launchd instead of systemd. We branch
+# on the handful of Windows-interop steps (gated on IS_WSL) and the supervisor.
+IS_WSL=""; IS_MAC=""
+case "$(uname -s)" in
+  Linux)  grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && IS_WSL=1 ;;
+  Darwin) IS_MAC=1 ;;
+  *)      die "HiveMind installs on Linux (native or WSL2) or macOS. This system ($(uname -s)) is neither." ;;
+esac
 
-# ── detect init system ──────────────────────────────────────────────────────
+# ── detect supervisor / init system ─────────────────────────────────────────
 INIT_SYSTEM="none"
-if command -v systemctl &>/dev/null; then
+if [ -n "$IS_MAC" ]; then
+  INIT_SYSTEM="launchd"
+elif command -v systemctl &>/dev/null; then
   INIT_SYSTEM="systemctl"
   loginctl enable-linger "$USER" 2>/dev/null || true
 elif [[ "$(ps -p 1 -o comm= 2>/dev/null | tr -d '[:space:]')" == "systemd" ]]; then
@@ -82,6 +88,7 @@ elif [ -d /etc/init.d ]; then
 fi
 
 case "$INIT_SYSTEM" in
+  launchd)   ok "Init system: launchd (macOS)" ;;
   systemctl) ok "Init system: systemctl" ;;
   systemd)   ok "Init system: systemd (no systemctl)" ;;
   initd)     ok "Init system: init.d" ;;
@@ -95,7 +102,7 @@ case "$INIT_SYSTEM" in
     ;;
 esac
 
-ok "Pre-flight OK ($([ -n "$IS_WSL" ] && echo 'WSL2' || echo 'native Linux'))"
+ok "Pre-flight OK ($([ -n "$IS_MAC" ] && echo 'macOS' || { [ -n "$IS_WSL" ] && echo 'WSL2' || echo 'native Linux'; }))"
 
 # ── Already installed AND running? Offer the lighter path before redoing the work. ──────────
 # Re-running install is safe and idempotent — it KEEPS this device's identity (STEP 5 reuses an
@@ -107,7 +114,7 @@ if [ -x "$HIVE_DIR/hv" ]; then
   _existing_device="$(cd "$HIVE_DIR" && ./hv config identity show 2>/dev/null | awk '/^device_id:/{print $2}')"
 fi
 _daemon_live=""
-if [ "$INIT_SYSTEM" = "systemctl" ] && systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+if command -v service_is_active >/dev/null 2>&1 && service_is_active "$SERVICE_NAME" 2>/dev/null; then
   _daemon_live=1
 fi
 if [ -n "$_existing_device" ] && [ -n "$_daemon_live" ]; then
@@ -176,10 +183,32 @@ fi
 fi  # end IS_WSL portproxy check
 
 # ════════════════════════════════════════════════════════════════════════════
-# STEP 2 — Tailscale in WSL
+# STEP 2 — Tailscale
 # ════════════════════════════════════════════════════════════════════════════
-step "2/$TOTAL  Tailscale (WSL)"
+step "2/$TOTAL  Tailscale"
 
+if [ -n "$IS_MAC" ]; then
+  # macOS: Tailscale ships as a GUI app (App Store / standalone) OR the brew CLI.
+  # Either way the app/`brew services` owns tailscaled — never `sudo systemctl` it.
+  TS_BIN="$(_resolve_tailscale || true)"
+  if [ -z "$TS_BIN" ] && command -v brew &>/dev/null; then
+    info "Installing Tailscale via Homebrew..."
+    brew install tailscale && TS_BIN="$(_resolve_tailscale || true)"
+  fi
+  if [ -z "$TS_BIN" ]; then
+    warn "Tailscale not found. Install the app from https://tailscale.com/download/mac"
+    warn "(or: brew install tailscale), authenticate, then re-run 'hive-mind install'."
+    TS_IP=""
+  else
+    ok "Tailscale present: $TS_BIN"
+    "$TS_BIN" up --ssh --accept-routes 2>/dev/null \
+      || warn "Run '$TS_BIN up --ssh' and authenticate if the daemon is not yet up."
+    TS_IP=$("$TS_BIN" ip 2>/dev/null | grep '^100\.' | head -1 | tr -d '[:space:]')
+    [ -n "$TS_IP" ] && ok "Tailscale IP: $TS_IP" || warn "No 100.x IP yet — authenticate Tailscale, then re-run."
+  fi
+
+else
+# ── Linux / WSL ──────────────────────────────────────────────────────────────
 # Install if not present
 if ! command -v tailscale &>/dev/null; then
   info "Installing Tailscale inside WSL..."
@@ -222,6 +251,7 @@ else
   ok "Authenticated: $TS_IP"
   ok "Tailscale SSH enabled"
 fi
+fi  # end Linux/WSL Tailscale branch
 
 # ════════════════════════════════════════════════════════════════════════════
 # STEP 3 — python3 + uv + requests
@@ -230,7 +260,12 @@ step "3/$TOTAL  Python dependencies"
 
 command -v python3 &>/dev/null || {
   info "Installing python3..."
-  sudo apt-get update -qq && sudo apt-get install -y -qq python3
+  if [ -n "$IS_MAC" ]; then
+    command -v brew &>/dev/null && brew install python \
+      || die "Python 3 not found. Install it (brew install python) and re-run."
+  else
+    sudo apt-get update -qq && sudo apt-get install -y -qq python3
+  fi
 }
 ok "python3 $(python3 --version)"
 
@@ -399,9 +434,15 @@ fi
 # ════════════════════════════════════════════════════════════════════════════
 # STEP 8 — Service / daemon persistence
 # ════════════════════════════════════════════════════════════════════════════
-step "8/$TOTAL  Systemd service"
+step "8/$TOTAL  Daemon supervision"
 
-if [[ "$INIT_SYSTEM" == "systemctl" || "$INIT_SYSTEM" == "systemd" ]]; then
+if [[ "$INIT_SYSTEM" == "launchd" ]]; then
+  # macOS launchd agents: hive-sync (KeepAlive) + hive-doctor (15-min self-heal).
+  launchd_install "$HIVE_DIR" "$SERVICE_NAME" \
+    && ok "launchd agents installed: hive-sync (KeepAlive) + hive-doctor (15-min self-heal)" \
+    || warn "launchd install reported a problem — check 'launchctl print gui/\$(id -u)/com.projectmentor.hive-sync'."
+
+elif [[ "$INIT_SYSTEM" == "systemctl" || "$INIT_SYSTEM" == "systemd" ]]; then
   # Hardened daemon unit + self-heal timer (see scripts/installer/_units.sh).
   write_systemd_units "$HIVE_DIR" "$SERVICE_NAME"
   ok "systemd units installed: hive-sync.service (hardened) + hive-doctor.timer"
@@ -439,7 +480,9 @@ fi
 # ════════════════════════════════════════════════════════════════════════════
 step "9/$TOTAL  Start sync daemon"
 
-if [[ "$INIT_SYSTEM" == "systemctl" || "$INIT_SYSTEM" == "systemd" ]]; then
+if [[ "$INIT_SYSTEM" == "launchd" ]]; then
+  launchd_restart "$SERVICE_NAME"
+elif [[ "$INIT_SYSTEM" == "systemctl" || "$INIT_SYSTEM" == "systemd" ]]; then
   systemctl --user restart "$SERVICE_NAME"
 elif [[ "$INIT_SYSTEM" == "initd" ]]; then
   sudo /etc/init.d/$SERVICE_NAME restart
@@ -452,7 +495,11 @@ sleep 2
 HELLO=$(curl -sf "http://127.0.0.1:9876/sync/hello" 2>/dev/null) && {
   ok "Daemon responding: $(echo "$HELLO" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("node_id","?"), "—", d.get("journal_entries","?"), "entries")')"
 } || {
-  warn "Daemon not yet responding on :9876. Check: journalctl --user -u $SERVICE_NAME -n 20"
+  if [[ "$INIT_SYSTEM" == "launchd" ]]; then
+    warn "Daemon not yet responding on :9876. Check: ~/Library/Logs/hive-mind/hive-sync.log"
+  else
+    warn "Daemon not yet responding on :9876. Check: journalctl --user -u $SERVICE_NAME -n 20"
+  fi
 }
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -501,6 +548,10 @@ mkdir -p "$BIN_DIR"
 if ! grep -q 'local/bin' "$HOME/.bashrc" 2>/dev/null; then
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
 fi
+# macOS defaults to zsh — also persist PATH there so `hv`/`hive-mind` resolve in new shells.
+if [ -n "$IS_MAC" ] && ! grep -q 'local/bin' "$HOME/.zshrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
+fi
 # Put `hv` on PATH so the CLI works from anywhere. hv resolves its own real directory
 # (Path(__file__).resolve()) for imports, so a symlink is fine.
 ln -sf "$HIVE_DIR/hv" "$BIN_DIR/hv"
@@ -537,8 +588,13 @@ echo ""
 echo "  Device:  $THIS_NODE"
 echo "  IP:      $THIS_IP"
 echo "  Data:    $HIVE_DIR"
-echo "  Daemon:  systemctl --user status $SERVICE_NAME"
-echo "  Logs:    journalctl --user -u $SERVICE_NAME -f"
+if [[ "$INIT_SYSTEM" == "launchd" ]]; then
+  echo "  Daemon:  launchctl print gui/\$(id -u)/com.projectmentor.hive-sync"
+  echo "  Logs:    ~/Library/Logs/hive-mind/hive-sync.log"
+else
+  echo "  Daemon:  systemctl --user status $SERVICE_NAME"
+  echo "  Logs:    journalctl --user -u $SERVICE_NAME -f"
+fi
 echo "  Try:     hv stats   (health check: hv doctor)"
 [ -z "$BIN_ON_PATH" ] && \
   echo "           ↳ new terminals work automatically; for THIS shell once: source ~/.bashrc"

--- a/scripts/installer/_launchd.sh
+++ b/scripts/installer/_launchd.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# =============================================================================
+# _launchd.sh — macOS launchd backend for the hive-mind supervisor.
+#
+# The Darwin analogue of _units.sh. Sourced by _service.sh only on macOS. Writes
+# two per-user LaunchAgents and loads them into the GUI domain:
+#
+#   com.projectmentor.hive-sync     KeepAlive=true      ≙ systemd Restart=always
+#   com.projectmentor.hive-doctor   StartInterval=900   ≙ hive-doctor.timer (15 min)
+#
+# Loaded with the modern `launchctl bootstrap gui/$UID` (not the deprecated
+# `launchctl load`); restarted with `launchctl kickstart -k`. Logs go to
+# ~/Library/Logs/hive-mind/. Every install bootout-then-bootstraps, so it is
+# idempotent (bootstrap errors if the label is already loaded).
+#
+# All overridable for tests / CI (see _launchd_render + --render-test below).
+# =============================================================================
+
+_LAUNCHD_PREFIX="com.projectmentor"
+_LAUNCHD_AGENTS_DIR="${_LAUNCHD_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
+_LAUNCHD_LOG_DIR="${_LAUNCHD_LOG_DIR:-$HOME/Library/Logs/hive-mind}"
+
+_launchd_domain() { echo "gui/$(id -u)"; }
+_launchd_plist_path() { echo "$_LAUNCHD_AGENTS_DIR/$_LAUNCHD_PREFIX.$1.plist"; }
+
+# Best interpreter for the plist ExecStart: Homebrew (Apple-Silicon/Intel) → PATH → system.
+# A LaunchAgent has no login PATH, so the plist must carry an absolute interpreter path.
+_launchd_python3() {
+  if command -v python3 >/dev/null 2>&1; then command -v python3; return; fi
+  local p
+  for p in /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3; do
+    [ -x "$p" ] && { echo "$p"; return; }
+  done
+  echo /usr/bin/python3
+}
+
+# Resolve the tailscale CLI on macOS: PATH (brew) first, then the GUI app bundle.
+# Prints the binary path, or nothing if neither is present.
+_resolve_tailscale() {
+  if command -v tailscale >/dev/null 2>&1; then command -v tailscale; return; fi
+  local app="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+  [ -x "$app" ] && echo "$app"
+}
+
+# _launchd_render <hive_dir> — write both plists to $_LAUNCHD_AGENTS_DIR. No launchctl.
+# Split out from launchd_install so tests/CI can render + lint without a GUI domain.
+_launchd_render() {
+  local hive_dir="$1" py plist
+  if [ -z "$hive_dir" ] || [ ! -f "$hive_dir/sync_daemon.py" ]; then
+    echo "_launchd_render: invalid hive_dir '$hive_dir' (no sync_daemon.py)" >&2
+    return 1
+  fi
+  py="$(_launchd_python3)"
+  mkdir -p "$_LAUNCHD_AGENTS_DIR" "$_LAUNCHD_LOG_DIR"
+
+  # ── the sync daemon: always-on (KeepAlive ≙ Restart=always, ThrottleInterval ≙ RestartSec) ──
+  plist="$(_launchd_plist_path hive-sync)"
+  cat > "$plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$_LAUNCHD_PREFIX.hive-sync</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$py</string>
+    <string>$hive_dir/sync_daemon.py</string>
+  </array>
+  <key>WorkingDirectory</key><string>$hive_dir</string>
+  <key>EnvironmentVariables</key>
+  <dict><key>HIVE_HOME</key><string>$hive_dir</string></dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>5</integer>
+  <key>StandardOutPath</key><string>$_LAUNCHD_LOG_DIR/hive-sync.log</string>
+  <key>StandardErrorPath</key><string>$_LAUNCHD_LOG_DIR/hive-sync.log</string>
+</dict>
+</plist>
+PLIST
+
+  # ── self-heal: `hv doctor --fix` on load + every 15 min (≙ hive-doctor.timer) ──
+  plist="$(_launchd_plist_path hive-doctor)"
+  cat > "$plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$_LAUNCHD_PREFIX.hive-doctor</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$py</string>
+    <string>$hive_dir/hv</string>
+    <string>doctor</string>
+    <string>--fix</string>
+  </array>
+  <key>WorkingDirectory</key><string>$hive_dir</string>
+  <key>EnvironmentVariables</key>
+  <dict><key>HIVE_HOME</key><string>$hive_dir</string></dict>
+  <key>RunAtLoad</key><true/>
+  <key>StartInterval</key><integer>900</integer>
+  <key>StandardOutPath</key><string>$_LAUNCHD_LOG_DIR/hive-doctor.log</string>
+  <key>StandardErrorPath</key><string>$_LAUNCHD_LOG_DIR/hive-doctor.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+# launchd_install <hive_dir> [svc] — render both plists then (re)load them into gui/$UID.
+# The svc arg is accepted for signature parity with write_systemd_units; labels are fixed.
+launchd_install() {
+  local hive_dir="$1" dom label plist
+  _launchd_render "$hive_dir" || return 1
+  dom="$(_launchd_domain)"
+  for label in hive-sync hive-doctor; do
+    plist="$(_launchd_plist_path "$label")"
+    if command -v plutil >/dev/null 2>&1; then
+      plutil -lint "$plist" >/dev/null 2>&1 || { echo "launchd_install: malformed plist $plist" >&2; return 1; }
+    fi
+    launchctl bootout   "$dom/$_LAUNCHD_PREFIX.$label" 2>/dev/null || true   # idempotent re-install
+    launchctl bootstrap "$dom" "$plist" 2>/dev/null || true
+    launchctl enable    "$dom/$_LAUNCHD_PREFIX.$label" 2>/dev/null || true
+  done
+}
+
+# launchd_restart [svc] — restart the named agent (default hive-sync).
+launchd_restart() {
+  launchctl kickstart -k "$(_launchd_domain)/$_LAUNCHD_PREFIX.${1:-hive-sync}" 2>/dev/null || true
+}
+
+# launchd_is_active [svc] — 0 if the agent is loaded in gui/$UID, else 1.
+launchd_is_active() {
+  launchctl print "$(_launchd_domain)/$_LAUNCHD_PREFIX.${1:-hive-sync}" >/dev/null 2>&1
+}
+
+# launchd_uninstall [svc] — bootout + remove both agents (idempotent; svc arg ignored).
+launchd_uninstall() {
+  local dom label
+  dom="$(_launchd_domain)"
+  for label in hive-sync hive-doctor; do
+    launchctl bootout "$dom/$_LAUNCHD_PREFIX.$label" 2>/dev/null || true
+    rm -f "$(_launchd_plist_path "$label")"
+  done
+}
+
+# `bash _launchd.sh --render-test` — render both plists to a temp dir and `plutil -lint` them.
+# Used by CI on macos-latest to validate the templates without bootstrapping into a GUI domain
+# (which a headless runner may lack). Only fires when executed directly, never when sourced.
+if [ "${BASH_SOURCE[0]:-x}" = "${0:-y}" ] && [ "${1:-}" = "--render-test" ]; then
+  set -e
+  _tmp="$(mktemp -d)"
+  _LAUNCHD_AGENTS_DIR="$_tmp/agents"
+  _LAUNCHD_LOG_DIR="$_tmp/logs"
+  _repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  _launchd_render "$_repo"
+  for _f in "$_LAUNCHD_AGENTS_DIR"/*.plist; do
+    echo "lint: $_f"
+    plutil -lint "$_f"
+  done
+  echo "render-test OK"
+fi

--- a/scripts/installer/_service.sh
+++ b/scripts/installer/_service.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================================
+# _service.sh — cross-platform supervisor seam for the hive-sync daemon.
+#
+# The supervisor that owns the daemon + the periodic self-heal differs by OS:
+#   Linux / WSL : systemd --user units  (see _units.sh — the single source of
+#                 truth, sourced and called VERBATIM here, so the Linux path is
+#                 byte-identical and carries zero regression risk).
+#   macOS       : launchd LaunchAgents  (see _launchd.sh).
+#
+# Callers ask `_service_kind` / the `service_*` wrappers instead of hard-coding
+# `systemctl`. The systemd branch delegates to the existing functions/commands,
+# so nothing that reaches the Linux kernel changes; macOS simply gets a second
+# branch. Sourced (not executed) by the installer scripts.
+# =============================================================================
+
+# Dir this file lives in — resolve so we can source siblings regardless of CWD.
+_SERVICE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# systemd unit writer (Linux) — always available; a no-op when no user systemd bus.
+if [ -f "$_SERVICE_LIB_DIR/_units.sh" ]; then . "$_SERVICE_LIB_DIR/_units.sh"; fi
+
+# launchd: the supervisor key. `systemd` covers native Linux + WSL (where the
+# concrete init may be systemctl/systemd/initd/cron — those sub-variants are
+# handled by the installer, not here).
+_service_kind() {
+  case "$(uname -s)" in
+    Darwin) echo launchd ;;
+    *)      echo systemd ;;
+  esac
+}
+
+# Pull in the launchd backend only on macOS (defines launchd_* + _resolve_tailscale).
+if [ "$(_service_kind)" = launchd ] && [ -f "$_SERVICE_LIB_DIR/_launchd.sh" ]; then
+  . "$_SERVICE_LIB_DIR/_launchd.sh"
+fi
+
+# service_install <hive_dir> [svc] — install + enable the supervisor units.
+service_install() {
+  case "$(_service_kind)" in
+    launchd) launchd_install "$@" ;;
+    *)       write_systemd_units "$@" ;;
+  esac
+}
+
+# service_restart [svc] — (re)start the sync daemon under the supervisor.
+service_restart() {
+  local svc="${1:-hive-sync}"
+  case "$(_service_kind)" in
+    launchd) launchd_restart "$svc" ;;
+    *)       systemctl --user restart "$svc" 2>/dev/null || true ;;
+  esac
+}
+
+# service_is_active [svc] — 0 if the daemon is supervised + running, else 1.
+service_is_active() {
+  local svc="${1:-hive-sync}"
+  case "$(_service_kind)" in
+    launchd) launchd_is_active "$svc" ;;
+    *)       systemctl --user is-active "$svc" --quiet 2>/dev/null ;;
+  esac
+}

--- a/scripts/installer/_status.sh
+++ b/scripts/installer/_status.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 HIVE_DIR="${HIVE_DIR:-$HOME/projects/hive-mind}"
 SERVICE="hive-sync"
 
+# Cross-platform supervisor seam (service_is_active, _resolve_tailscale on macOS).
+_SVCLIB="$HIVE_DIR/scripts/installer/_service.sh"
+if [ -f "$_SVCLIB" ]; then . "$_SVCLIB"; fi
+
 RED='\033[0;31m'; GRN='\033[0;32m'; YLW='\033[1;33m'; BLD='\033[1m'; RST='\033[0m'
 ok()   { echo -e "${GRN}[ok]${RST}  $*"; }
 warn() { echo -e "${YLW}[!!]${RST}  $*"; }
@@ -15,10 +19,10 @@ echo -e "${BLD}hive-mind status${RST}"
 echo "────────────────────────────────────"
 
 # Daemon
-if systemctl --user is-active "$SERVICE" --quiet 2>/dev/null; then
-  ok "Daemon: running  (systemctl --user status $SERVICE)"
+if command -v service_is_active >/dev/null 2>&1 && service_is_active "$SERVICE" 2>/dev/null; then
+  ok "Daemon: running"
 else
-  bad "Daemon: not running  (journalctl --user -u $SERVICE -n 20)"
+  bad "Daemon: not running"
 fi
 
 # /sync/hello
@@ -35,12 +39,22 @@ if [ -x "$HIVE_DIR/hv" ]; then
 fi
 
 # Tailscale
-TS_IP=$(powershell.exe -NoProfile -Command "try { (& tailscale ip 2>null).Trim() } catch { '' }" 2>/dev/null | tr -d '\r' | head -1) || true
-if [[ -n "$TS_IP" ]]; then
-  ok "Tailscale: $TS_IP"
-  ip addr show 2>/dev/null | grep -q "$TS_IP" && ok "Mirrored networking: active" \
-    || warn "Mirrored networking: Tailscale IP not visible in WSL (run wsl --shutdown)"
-fi
+case "$(uname -s)" in
+  Darwin)
+    TSBIN="$(_resolve_tailscale 2>/dev/null || true)"
+    TS_IP=$([ -n "$TSBIN" ] && "$TSBIN" ip 2>/dev/null | grep '^100\.' | head -1 | tr -d '[:space:]') || true
+    [[ -n "$TS_IP" ]] && ok "Tailscale: $TS_IP" || warn "Tailscale: no 100.x IP (is Tailscale running + authenticated?)"
+    ;;
+  *)
+    # WSL: query the Windows host's tailscale via interop; native Linux has no powershell.exe (skips).
+    TS_IP=$(powershell.exe -NoProfile -Command "try { (& tailscale ip 2>null).Trim() } catch { '' }" 2>/dev/null | tr -d '\r' | head -1) || true
+    if [[ -n "$TS_IP" ]]; then
+      ok "Tailscale: $TS_IP"
+      ip addr show 2>/dev/null | grep -q "$TS_IP" && ok "Mirrored networking: active" \
+        || warn "Mirrored networking: Tailscale IP not visible in WSL (run wsl --shutdown)"
+    fi
+    ;;
+esac
 
 # Peers
 PEERS_FILE="$HIVE_DIR/.peers.json"

--- a/scripts/installer/_uninstall.sh
+++ b/scripts/installer/_uninstall.sh
@@ -66,19 +66,28 @@ fi
 
 # ── 1. sync daemon + self-heal timer ─────────────────────────────────────────
 info "Stopping and removing the sync daemon..."
-systemctl --user disable --now hive-doctor.timer 2>/dev/null || true
-systemctl --user stop hive-doctor.service        2>/dev/null || true
-rm -f "$DOCTOR_TIMER" "$DOCTOR_SVC"
-systemctl --user stop "$SERVICE_NAME"        2>/dev/null || true
-systemctl --user disable "$SERVICE_NAME"     2>/dev/null || true
-rm -f "$UNIT_FILE"
-systemctl --user daemon-reload               2>/dev/null || true
-systemctl --user reset-failed "$SERVICE_NAME" 2>/dev/null || true
-systemctl --user reset-failed hive-doctor.service 2>/dev/null || true
-if [ -z "${HIVE_UNINSTALL_TEST:-}" ]; then
-  pkill -f "sync_daemon.py" 2>/dev/null || true    # any stray/non-systemd daemon
-  if crontab -l 2>/dev/null | grep -q "sync_daemon.py"; then
-    crontab -l 2>/dev/null | grep -v "sync_daemon.py" | crontab - 2>/dev/null || true
+if [ "$(uname -s)" = "Darwin" ]; then
+  # macOS launchd: bootout both agents from the per-user GUI domain + remove the plists.
+  for _l in hive-sync hive-doctor; do
+    launchctl bootout "gui/$(id -u)/com.projectmentor.$_l" 2>/dev/null || true
+    rm -f "$HOME/Library/LaunchAgents/com.projectmentor.$_l.plist"
+  done
+  [ -z "${HIVE_UNINSTALL_TEST:-}" ] && pkill -f "sync_daemon.py" 2>/dev/null || true
+else
+  systemctl --user disable --now hive-doctor.timer 2>/dev/null || true
+  systemctl --user stop hive-doctor.service        2>/dev/null || true
+  rm -f "$DOCTOR_TIMER" "$DOCTOR_SVC"
+  systemctl --user stop "$SERVICE_NAME"        2>/dev/null || true
+  systemctl --user disable "$SERVICE_NAME"     2>/dev/null || true
+  rm -f "$UNIT_FILE"
+  systemctl --user daemon-reload               2>/dev/null || true
+  systemctl --user reset-failed "$SERVICE_NAME" 2>/dev/null || true
+  systemctl --user reset-failed hive-doctor.service 2>/dev/null || true
+  if [ -z "${HIVE_UNINSTALL_TEST:-}" ]; then
+    pkill -f "sync_daemon.py" 2>/dev/null || true    # any stray/non-systemd daemon
+    if crontab -l 2>/dev/null | grep -q "sync_daemon.py"; then
+      crontab -l 2>/dev/null | grep -v "sync_daemon.py" | crontab - 2>/dev/null || true
+    fi
   fi
 fi
 ok "Daemon stopped and removed."

--- a/scripts/installer/_update.sh
+++ b/scripts/installer/_update.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 HIVE_DIR="${HIVE_DIR:-$HOME/projects/hive-mind}"
 SERVICE="hive-sync"
 
-# Shared systemd-unit writer — lets `update` re-apply the hardened unit + the
-# self-heal timer to already-installed nodes (not just fresh installs).
-_UNITLIB="$HIVE_DIR/scripts/installer/_units.sh"
-[ -f "$_UNITLIB" ] && . "$_UNITLIB"
+# Cross-platform supervisor seam — lets `update` re-apply the hardened daemon
+# units (systemd on Linux/WSL, launchd on macOS) to already-installed nodes, not
+# just fresh installs. Exposes service_install / service_restart.
+_SVCLIB="$HIVE_DIR/scripts/installer/_service.sh"
+if [ -f "$_SVCLIB" ]; then . "$_SVCLIB"; fi
 
 GRN='\033[0;32m'; BLD='\033[1m'; RST='\033[0m'
 ok()   { echo -e "${GRN}[ok]${RST}  $*"; }
@@ -45,10 +46,10 @@ info "Rebuilding database..."
 cd "$HIVE_DIR" && ./hv rebuild
 ok "DB rebuilt"
 
-info "Refreshing systemd units..."
-if command -v write_systemd_units >/dev/null 2>&1; then
-  write_systemd_units "$HIVE_DIR" "$SERVICE"
-  ok "Units refreshed (hive-sync hardened + hive-doctor self-heal timer)"
+info "Refreshing supervisor units..."
+if command -v service_install >/dev/null 2>&1; then
+  service_install "$HIVE_DIR" "$SERVICE"
+  ok "Units refreshed (hive-sync + hive-doctor self-heal)"
 fi
 
 # Re-assert the Claude Code integration so an update from before a hook existed picks it up here,
@@ -59,10 +60,14 @@ if [ -d "$HOME/.claude" ] || command -v claude >/dev/null 2>&1; then
 fi
 
 info "Restarting sync daemon..."
-systemctl --user restart "$SERVICE" 2>/dev/null || true
+if command -v service_restart >/dev/null 2>&1; then
+  service_restart "$SERVICE"
+else
+  systemctl --user restart "$SERVICE" 2>/dev/null || true
+fi
 sleep 2
 curl -sf http://127.0.0.1:9876/sync/hello >/dev/null && ok "Daemon responding" \
-  || echo "  Daemon may still be starting — check: journalctl --user -u $SERVICE -f"
+  || echo "  Daemon may still be starting — check the daemon logs."
 
 echo ""
 ok "Update complete"

--- a/scripts/installer/dispatcher.sh
+++ b/scripts/installer/dispatcher.sh
@@ -7,7 +7,21 @@
 # current — new subcommands show up with no reinstall. It resolves its own repo
 # location, so it works regardless of where the repo lives.
 # =============================================================================
-SELF="$(readlink -f "${BASH_SOURCE[0]}")"
+# Resolve this script's real path, following symlinks (the installer symlinks
+# ~/.local/bin/hive-mind here). BSD `readlink` on macOS lacks `-f`, so resolve
+# the symlink chain portably instead of relying on the GNU extension.
+_resolve_self() {
+  local p="${BASH_SOURCE[0]}" t
+  while [ -L "$p" ]; do
+    t="$(readlink "$p")"
+    case "$t" in
+      /*) p="$t" ;;
+      *)  p="$(cd "$(dirname "$p")" && pwd)/$t" ;;
+    esac
+  done
+  printf '%s\n' "$(cd "$(dirname "$p")" && pwd -P)/$(basename "$p")"
+}
+SELF="$(_resolve_self)"
 HIVE_DIR="${HIVE_DIR:-$(cd "$(dirname "$SELF")/../.." && pwd)}"
 INSTALLER="$HIVE_DIR/scripts/installer"
 CMD="${1:-help}"

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -46,10 +46,12 @@ echo -e "${BLD}hive-mind installer${RST}"
 echo "────────────────────────────────────────────"
 echo ""
 
-# ── guard: must be WSL ─────────────────────────────────────────────────────
-if ! grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
-  die "This installer is for WSL2 on Windows 11. Not detected."
-fi
+# ── guard: supported OS (Linux native, WSL2 on Windows 11, or macOS) ────────
+case "$(uname -s)" in
+  Linux)  : ;;   # native Linux, or WSL2 on Windows 11 — both fine
+  Darwin) : ;;   # macOS
+  *)      die "Unsupported OS: $(uname -s). HiveMind supports Linux, WSL2, and macOS." ;;
+esac
 
 # ── 1. ensure ~/.local/bin exists and is on PATH ───────────────────────────
 mkdir -p "$BIN_DIR"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,83 @@
+"""Cross-platform supervisor seam (scripts/installer/_service.sh + _launchd.sh).
+
+These run on every CI OS (ubuntu + macos). They exercise the NEW macOS code paths
+without needing a Mac: the launchd plists are rendered by bash and validated with
+Python's stdlib ``plistlib`` (no ``plutil``), and ``_service_kind`` dispatch is checked
+by shimming ``uname`` onto PATH. A golden-parity check proves sourcing ``_service.sh``
+leaves the systemd unit writer byte-identical, so the Linux path carries no regression.
+"""
+import os
+import plistlib
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INSTALLER = REPO / "scripts" / "installer"
+LAUNCHD = INSTALLER / "_launchd.sh"
+SERVICE = INSTALLER / "_service.sh"
+UNITS = INSTALLER / "_units.sh"
+
+
+def _bash(script, env=None, path_prefix=None):
+    """Run a bash snippet; return CompletedProcess. Optionally prepend path_prefix to PATH."""
+    e = dict(os.environ)
+    if env:
+        e.update(env)
+    if path_prefix:
+        e["PATH"] = f"{path_prefix}:{e['PATH']}"
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=e)
+
+
+def test_launchd_renders_well_formed_plists(tmp_path):
+    """_launchd_render writes two plists that parse and carry the systemd-equivalent keys."""
+    agents = tmp_path / "agents"
+    r = _bash(
+        f'. "{LAUNCHD}"; _launchd_render "{REPO}"',
+        env={"_LAUNCHD_AGENTS_DIR": str(agents), "_LAUNCHD_LOG_DIR": str(tmp_path / "logs")},
+    )
+    assert r.returncode == 0, r.stderr
+
+    sync = plistlib.loads((agents / "com.projectmentor.hive-sync.plist").read_bytes())
+    assert sync["Label"] == "com.projectmentor.hive-sync"
+    assert sync["RunAtLoad"] is True
+    assert sync["KeepAlive"] is True          # ≙ systemd Restart=always
+    assert sync["ThrottleInterval"] == 5      # ≙ RestartSec=5
+    assert sync["ProgramArguments"][-1].endswith("/sync_daemon.py")
+    assert sync["EnvironmentVariables"]["HIVE_HOME"] == str(REPO)
+
+    doctor = plistlib.loads((agents / "com.projectmentor.hive-doctor.plist").read_bytes())
+    assert doctor["StartInterval"] == 900     # ≙ hive-doctor.timer OnUnitActiveSec=15min
+    assert doctor["ProgramArguments"][-2:] == ["doctor", "--fix"]
+
+
+def test_launchd_render_rejects_bad_hive_dir(tmp_path):
+    """A hive_dir without sync_daemon.py must fail loudly rather than write a broken plist."""
+    r = _bash(f'. "{LAUNCHD}"; _launchd_render "{tmp_path}"')
+    assert r.returncode != 0
+    assert "no sync_daemon.py" in r.stderr
+
+
+def test_service_kind_dispatch():
+    """_service_kind returns systemd on this (Linux/CI) host, and launchd when uname says Darwin."""
+    here = _bash(f'. "{SERVICE}"; _service_kind')
+    assert here.stdout.strip() in ("systemd", "launchd")
+
+    shim = REPO / "tests"  # any dir; we drop a fake `uname` into a temp dir instead
+    fake = subprocess.run(["mktemp", "-d"], capture_output=True, text=True).stdout.strip()
+    Path(fake, "uname").write_text("#!/bin/sh\necho Darwin\n")
+    os.chmod(Path(fake, "uname"), 0o755)
+    darwin = _bash(
+        f'. "{SERVICE}"; _service_kind; type launchd_install >/dev/null 2>&1 && echo BACKEND',
+        path_prefix=fake,
+    )
+    assert darwin.stdout.split()[0] == "launchd"
+    assert "BACKEND" in darwin.stdout, "launchd backend must be sourced on Darwin"
+
+
+def test_systemd_writer_byte_identical_via_service():
+    """Sourcing _service.sh must not alter write_systemd_units — the Linux path stays verbatim."""
+    direct = _bash(f'. "{UNITS}"; declare -f write_systemd_units')
+    viaserv = _bash(f'. "{SERVICE}"; declare -f write_systemd_units')
+    assert direct.returncode == 0 and viaserv.returncode == 0
+    assert direct.stdout == viaserv.stdout
+    assert "write_systemd_units" in direct.stdout

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -36,7 +36,9 @@ def _free_port():
     return port
 
 
-def _wait_until_serving(port, timeout=15):
+def _wait_until_serving(port, timeout=45):
+    # Generous budget: cold daemon startup imports hv + crypto and binds the port, which
+    # can take >15s on a loaded, slow CI runner (e.g. GitHub macos-latest, ~2x slower).
     deadline = time.time() + timeout
     url = f"http://127.0.0.1:{port}/sync/merkle-root"
     while time.time() < deadline:


### PR DESCRIPTION
Closes #5.

HiveMind ran only on Linux/WSL2 — the Mac dev crowd (our most likely early adopters) couldn't install it. The `hv` core was already portable (detects `darwin`, syscalls degrade gracefully, pure-Python crypto); the blockers were entirely in the installer/service layer. This ports that layer with **zero Linux regression** (full suite: 205 passed).

## Supervisor seam (new)
- **`scripts/installer/_launchd.sh`** — macOS launchd backend (the `_units.sh` analogue): renders `com.projectmentor.hive-sync` (`KeepAlive` ≙ `Restart=always`) + `com.projectmentor.hive-doctor` (`StartInterval=900` ≙ the 15-min self-heal timer), loads them with the modern `launchctl bootstrap gui/$UID`, logs to `~/Library/Logs/hive-mind/`. `--render-test` lints plists in CI.
- **`scripts/installer/_service.sh`** — dispatch (`_service_kind` + `service_install/restart/is_active`). The systemd path delegates to `write_systemd_units`/`systemctl` **verbatim**, so the Linux bytes are byte-identical (golden-parity test).

## Installer / portable shims
- `dispatcher.sh`: POSIX symlink-resolving loop replaces GNU `readlink -f`.
- `install.sh`: OS-case guard (Linux/Darwin) replaces the WSL-or-die check.
- `_install_node.sh`: accept Darwin, `INIT_SYSTEM=launchd`; darwin branches for Tailscale (brew/app, never `sudo systemctl tailscaled`), python via brew, launchd install/start, zsh PATH, platform-aware summary.
- `_update.sh` / `_uninstall.sh` / `_status.sh` routed through the seam; Linux blocks untouched.

## Runtime (hv)
The one irreducible Python seam: `doctor --fix`'s restart at `hv:3978` was systemctl-only → added `_launchd_hive_sync()` + a darwin `launchctl kickstart` branch, else a crashed launchd agent never self-heals. Orphan **detection** was already cross-platform.

## CI / tests
- `ci.yml`: pytest matrix (ubuntu + **macos-latest**) + a `macos-installer-smoke` job (symlink resolve, `plutil -lint`, native daemon `/sync/hello`, best-effort bootstrap, idempotent uninstall).
- `tests/test_service.py`: plist rendering (plistlib), `_service_kind` dispatch, systemd-writer byte-parity.

## Docs
README / CLI_REFERENCE / THREAT_MODEL / SYNC_API note macOS + launchd.

## Real-Mac gaps (no Mac available — honest scope)
CI cannot prove: `launchctl bootstrap` under a real login session, reboot persistence, live Tailscale auth + GUI-app path, two-node tailnet sync. These are deferred to the cloud-Mac → community-beta-tester tiers of the verification ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)