### PR TITLE
feat(android): Termux (termux-services/runit) installer seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,26 @@ jobs:
             || echo "gui domain unavailable in headless CI — bootstrap unverifiable here (needs a real Mac)"
       - name: service uninstall is idempotent
         run: bash -c '. scripts/installer/_service.sh; launchd_uninstall hive-sync; launchd_uninstall hive-sync'
+
+  # Android/Termux supervisor seam, exercised on an ordinary Linux runner (no phone,
+  # no termux-services). `TERMUX_VERSION=1` forces the runit branch in _service.sh, so
+  # we can validate kind detection + the rendered runit/Termux:Boot scripts without a
+  # device. What it CANNOT prove (needs a real phone): that `sv`/runsvdir actually
+  # supervise the daemon, Termux:Boot fires on reboot, and the app-owned Tailscale tun.
+  android-installer-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: runit run/boot scripts render + sh -n lint
+        run: bash scripts/installer/_runit.sh --render-test
+      - name: _service_kind resolves to runit under a Termux environment
+        run: TERMUX_VERSION=1 bash -c '. scripts/installer/_service.sh; [ "$(_service_kind)" = runit ] && type runit_install >/dev/null'
+      - name: _service_kind stays systemd on an ordinary Linux runner (no regression)
+        run: bash -c '. scripts/installer/_service.sh; [ "$(_service_kind)" = systemd ]'
+      - name: runit_uninstall is idempotent
+        run: TERMUX_VERSION=1 bash -c '. scripts/installer/_service.sh; runit_uninstall hive-sync; runit_uninstall hive-sync'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ apart from Pinecone, Weaviate, LlamaIndex, LangGraph, and friends.
 
 ## Install
 
-On macOS, Linux, or a WSL terminal on Windows 11, run:
+On Android (Termux), Linux, macOS, or a WSL terminal on Windows 11, run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/projectmentor/hive-mind/main/scripts/installer/install.sh | bash
@@ -70,18 +70,39 @@ The installer will:
    Enter** — you can add peers later by editing `.peers.json`.
 5. Initialise the local database
 6. Install and start the sync daemon under your OS's service manager (systemd on Linux/WSL,
-   launchd on macOS)
+   launchd on macOS, termux-services/runit on Android)
 7. Wire the Hermes memory plugin (if Hermes is installed)
 
 ### Requirements
 
-- **macOS**, **Linux** (native), or **Windows 11 with WSL2** (with systemd enabled). Android
-  support is in progress. On macOS the daemon runs as a launchd LaunchAgent.
+- **Android** (Termux), **Linux** (native), **macOS**, or **Windows 11 with WSL2** (with
+  systemd enabled). The daemon runs under each platform's supervisor: systemd on Linux/WSL,
+  launchd on macOS, termux-services/runit on Android (plus Termux:Boot for start-on-reboot).
 - **Internet access** (for the install and git clone)
 - **Tailscale** *only if you want multiple machines to sync.* The installer sets it up for
-  you (inside WSL on Windows; on macOS install the app or `brew install tailscale`; it is
-  **not** needed on the Windows host). A single-machine setup needs no Tailscale at all —
-  there are no peers to reach.
+  you (inside WSL on Windows; on macOS install the app or `brew install tailscale`). On
+  **Android** Tailscale is the VPN app — install and connect it from the Play Store/F-Droid;
+  the installer can't manage it from Termux. It is **not** needed on the Windows host. A
+  single-machine setup needs no Tailscale at all — there are no peers to reach.
+
+<details>
+<summary>Android (Termux) setup notes</summary>
+
+```bash
+# In Termux (install it from F-Droid, not the Play Store build):
+pkg install python git
+curl -fsSL https://raw.githubusercontent.com/projectmentor/hive-mind/main/scripts/installer/install.sh | bash
+hive-mind install
+```
+
+The installer adds `termux-services` (runit) to keep the daemon alive while Termux runs. For
+start-on-reboot, install the **Termux:Boot** app from F-Droid, open it once, and disable
+battery optimisation for Termux + Termux:Boot so Android Doze doesn't freeze the daemon.
+Connect the Tailscale Android app before syncing. A phone behind Tailscale's userspace VPN
+can't accept inbound connections, but it doesn't need to: it converges by syncing outbound
+every 5 minutes.
+
+</details>
 
 <details>
 <summary>Enable systemd in WSL (if it isn't already)</summary>
@@ -198,7 +219,7 @@ the policy and the common failure modes.
 
 - **Federated hives (a colony)** — separate hives (personal, team, project) that selectively share
   what matters, so groups pool knowledge without merging into one pool. Multiple hives form a colony.
-- **More platforms** — Android (macOS, Linux, and WSL2 are supported today).
+- **More platforms** — iOS / thin-client nodes (Android, Linux, macOS, and WSL2 are supported today).
 - **Hosted relay** — an optional managed tier for nodes that can't reach each other directly.
 
 ---

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -778,14 +778,17 @@ This file is not synced to git — it's specific to each machine.
 ./hv sync daemon
 
 # Check background service status
+sv status hive-sync                                        # Android (Termux)
 systemctl --user status hive-sync                          # Linux / WSL
 launchctl print gui/$(id -u)/com.projectmentor.hive-sync   # macOS
 
 # Watch sync logs live
+tail -f ~/.hive-mind/logs/hive-sync.log                    # Android (Termux)
 journalctl --user -u hive-sync -f                          # Linux / WSL
 tail -f ~/Library/Logs/hive-mind/hive-sync.log             # macOS
 
 # Restart the background service (e.g. after editing peers.json)
+sv restart hive-sync                                                 # Android (Termux)
 systemctl --user restart hive-sync                                   # Linux / WSL
 launchctl kickstart -k gui/$(id -u)/com.projectmentor.hive-sync      # macOS
 ```

--- a/hv
+++ b/hv
@@ -3993,7 +3993,7 @@ def doctor_cmd(args):
             print(f"\n--fix: killing {len(orphans)} orphan daemon(s): {', '.join(map(str, orphans))}")
             _kill_orphans(orphans)
             # Restart the supervisor-managed daemon so the just-cleared port is reclaimed by the
-            # canonical instance: systemd on Linux/WSL, launchd on macOS.
+            # canonical instance: systemd on Linux/WSL, launchd on macOS, runit on Android/Termux.
             if sys.platform == "darwin":
                 if _launchd_hive_sync()[0]:
                     subprocess.run(["launchctl", "kickstart", "-k",
@@ -4001,6 +4001,13 @@ def doctor_cmd(args):
                                    capture_output=True)
                     time.sleep(2)
                     print("  restarted the launchd hive-sync agent.")
+            elif os.environ.get("TERMUX_VERSION") or os.path.isdir("/data/data/com.termux"):
+                # Android/Termux: sys.platform is "linux" but there is no systemd; runit's
+                # runsvdir respawns the daemon on its own, so this is best-effort parity.
+                if shutil.which("sv"):
+                    subprocess.run(["sv", "restart", "hive-sync"], capture_output=True)
+                    time.sleep(2)
+                    print("  restarted the runit hive-sync service.")
             else:
                 unit_exists, _ = _systemd_hive_sync()
                 if unit_exists:

--- a/scripts/installer/_install_node.sh
+++ b/scripts/installer/_install_node.sh
@@ -63,19 +63,31 @@ echo ""
 # ════════════════════════════════════════════════════════════════════════════
 step "1/$TOTAL  Pre-flight checks"
 
-# HiveMind runs on Linux (native or WSL2) and macOS. WSL2 is a Linux kernel, so
-# native Linux works the same; macOS uses launchd instead of systemd. We branch
-# on the handful of Windows-interop steps (gated on IS_WSL) and the supervisor.
-IS_WSL=""; IS_MAC=""
+# HiveMind runs on Linux (native or WSL2), macOS, and Android (Termux). WSL2 is a
+# Linux kernel, so native Linux works the same; macOS uses launchd; Android uses
+# termux-services/runit. Termux reports `uname -s`=Linux, so it is matched FIRST
+# (via `uname -o`=Android / $TERMUX_VERSION / the Termux data dir) before the WSL
+# probe. We branch on the Windows-interop steps (IS_WSL) and the supervisor.
+IS_WSL=""; IS_MAC=""; IS_ANDROID=""
 case "$(uname -s)" in
-  Linux)  grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null && IS_WSL=1 ;;
+  Linux)
+    if [ "$(uname -o 2>/dev/null)" = "Android" ] || [ -n "${TERMUX_VERSION:-}" ] \
+       || [ -d /data/data/com.termux ]; then
+      IS_ANDROID=1
+    elif grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
+      IS_WSL=1
+    fi ;;
   Darwin) IS_MAC=1 ;;
-  *)      die "HiveMind installs on Linux (native or WSL2) or macOS. This system ($(uname -s)) is neither." ;;
+  *)      die "HiveMind installs on Linux (native or WSL2), macOS, or Android (Termux). This system ($(uname -s)) is none." ;;
 esac
 
 # ── detect supervisor / init system ─────────────────────────────────────────
+# Android FIRST: Termux has no systemctl / systemd PID 1 / loginctl, so the probes
+# below would error or mis-fire there.
 INIT_SYSTEM="none"
-if [ -n "$IS_MAC" ]; then
+if [ -n "$IS_ANDROID" ]; then
+  INIT_SYSTEM="runit"
+elif [ -n "$IS_MAC" ]; then
   INIT_SYSTEM="launchd"
 elif command -v systemctl &>/dev/null; then
   INIT_SYSTEM="systemctl"
@@ -89,6 +101,7 @@ fi
 
 case "$INIT_SYSTEM" in
   launchd)   ok "Init system: launchd (macOS)" ;;
+  runit)     ok "Init system: termux-services / runit (Android)" ;;
   systemctl) ok "Init system: systemctl" ;;
   systemd)   ok "Init system: systemd (no systemctl)" ;;
   initd)     ok "Init system: init.d" ;;
@@ -102,7 +115,24 @@ case "$INIT_SYSTEM" in
     ;;
 esac
 
-ok "Pre-flight OK ($([ -n "$IS_MAC" ] && echo 'macOS' || { [ -n "$IS_WSL" ] && echo 'WSL2' || echo 'native Linux'; }))"
+ok "Pre-flight OK ($([ -n "$IS_MAC" ] && echo 'macOS' || { [ -n "$IS_ANDROID" ] && echo 'Android (Termux)' || { [ -n "$IS_WSL" ] && echo 'WSL2' || echo 'native Linux'; }; }))"
+
+# ── Android: ensure termux-services (runit) is present + nudge Termux:Boot ───
+# Termux has no systemd; termux-services provides `sv`/runsvdir. Termux:Boot (a
+# separate F-Droid app) gives start-on-reboot — the CLI can only prompt for it.
+if [ -n "$IS_ANDROID" ]; then
+  if ! command -v sv &>/dev/null; then
+    info "Installing termux-services (runit supervisor)..."
+    pkg install -y termux-services 2>/dev/null || warn "pkg install termux-services failed — will fall back to a nohup keep-alive."
+  fi
+  # Bring the supervisor tree up for THIS session if a login shell hasn't already.
+  if ! pgrep -x runsvdir >/dev/null 2>&1; then
+    . "$PREFIX/etc/profile.d/start-services.sh" 2>/dev/null || true
+  fi
+  warn "For start-on-reboot: install the Termux:Boot app from F-Droid, open it once,"
+  warn "then disable battery optimisation for Termux + Termux:Boot. (Keep-alive while"
+  warn "running works without it.)"
+fi
 
 # ── Already installed AND running? Offer the lighter path before redoing the work. ──────────
 # Re-running install is safe and idempotent — it KEEPS this device's identity (STEP 5 reuses an
@@ -187,7 +217,28 @@ fi  # end IS_WSL portproxy check
 # ════════════════════════════════════════════════════════════════════════════
 step "2/$TOTAL  Tailscale"
 
-if [ -n "$IS_MAC" ]; then
+if [ -n "$IS_ANDROID" ]; then
+  # Android: Tailscale is the VPN APP (userspace), not a Termux CLI — the installer
+  # cannot run `tailscale up`. The 100.x address lives on an app-owned tun that may
+  # not even be visible inside Termux, so discovery is best-effort. TS_IP is only
+  # used for display + the `self` label; joining points at the PEER and sync is
+  # outbound, so a missing IP is non-fatal.
+  TS_IP="$( { command -v ip >/dev/null 2>&1 && ip -4 addr 2>/dev/null; \
+              command -v ifconfig >/dev/null 2>&1 && ifconfig 2>/dev/null; } \
+            | grep -oE '100\.[0-9]+\.[0-9]+\.[0-9]+' | head -1 )"
+  if [ -n "$TS_IP" ]; then
+    ok "Tailscale IP (from VPN tun): $TS_IP"
+  else
+    warn "Can't read the Tailscale IP from Termux (the VPN tun is owned by the app)."
+    warn "Open the Tailscale app and confirm it shows Connected."
+    if [ -t 0 ]; then
+      ask "Paste this device's Tailscale 100.x IP (optional, Enter to skip): "
+      read -r TS_IP
+    fi
+    TS_IP="${TS_IP:-}"
+  fi
+
+elif [ -n "$IS_MAC" ]; then
   # macOS: Tailscale ships as a GUI app (App Store / standalone) OR the brew CLI.
   # Either way the app/`brew services` owns tailscaled — never `sudo systemctl` it.
   TS_BIN="$(_resolve_tailscale || true)"
@@ -258,31 +309,45 @@ fi  # end Linux/WSL Tailscale branch
 # ════════════════════════════════════════════════════════════════════════════
 step "3/$TOTAL  Python dependencies"
 
-command -v python3 &>/dev/null || {
-  info "Installing python3..."
-  if [ -n "$IS_MAC" ]; then
-    command -v brew &>/dev/null && brew install python \
-      || die "Python 3 not found. Install it (brew install python) and re-run."
-  else
-    sudo apt-get update -qq && sudo apt-get install -y -qq python3
+if [ -n "$IS_ANDROID" ]; then
+  # Termux: `pkg` not apt, no sudo, no root. The core only needs `requests`, and
+  # `uv` has no reliable Termux/aarch64 wheel — so install python/git via pkg and
+  # requests via plain pip, skipping uv entirely.
+  command -v python3 &>/dev/null || { info "Installing python (pkg)..."; pkg install -y python; }
+  command -v git     &>/dev/null || { info "Installing git (pkg)...";    pkg install -y git; }
+  ok "python3 $(python3 --version)"
+  python3 -c "import requests" 2>/dev/null || {
+    info "Installing requests (pip)..."
+    pip install requests
+  }
+  ok "requests available (Termux, no uv)"
+else
+  command -v python3 &>/dev/null || {
+    info "Installing python3..."
+    if [ -n "$IS_MAC" ]; then
+      command -v brew &>/dev/null && brew install python \
+        || die "Python 3 not found. Install it (brew install python) and re-run."
+    else
+      sudo apt-get update -qq && sudo apt-get install -y -qq python3
+    fi
+  }
+  ok "python3 $(python3 --version)"
+
+  if ! command -v uv &>/dev/null; then
+    info "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    source "$HOME/.local/bin/env" 2>/dev/null \
+      || source "$HOME/.cargo/env" 2>/dev/null \
+      || export PATH="$HOME/.local/bin:$PATH"
   fi
-}
-ok "python3 $(python3 --version)"
+  ok "uv $(uv --version)"
 
-if ! command -v uv &>/dev/null; then
-  info "Installing uv..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  source "$HOME/.local/bin/env" 2>/dev/null \
-    || source "$HOME/.cargo/env" 2>/dev/null \
-    || export PATH="$HOME/.local/bin:$PATH"
+  python3 -c "import requests" 2>/dev/null || {
+    info "Installing requests..."
+    uv pip install --system requests
+  }
+  ok "requests available"
 fi
-ok "uv $(uv --version)"
-
-python3 -c "import requests" 2>/dev/null || {
-  info "Installing requests..."
-  uv pip install --system requests
-}
-ok "requests available"
 
 # ════════════════════════════════════════════════════════════════════════════
 # STEP 4 — Clone / update repo
@@ -442,6 +507,22 @@ if [[ "$INIT_SYSTEM" == "launchd" ]]; then
     && ok "launchd agents installed: hive-sync (KeepAlive) + hive-doctor (15-min self-heal)" \
     || warn "launchd install reported a problem — check 'launchctl print gui/\$(id -u)/com.projectmentor.hive-sync'."
 
+elif [[ "$INIT_SYSTEM" == "runit" ]]; then
+  # Android/Termux: runit services hive-sync (runsvdir respawn) + hive-doctor
+  # (15-min loop), plus a Termux:Boot entrypoint. See scripts/installer/_runit.sh.
+  if command -v runit_install >/dev/null 2>&1 && command -v sv >/dev/null 2>&1; then
+    runit_install "$HIVE_DIR" "$SERVICE_NAME" \
+      && ok "runit services installed: hive-sync (keep-alive) + hive-doctor (15-min loop)" \
+      || warn "runit install reported a problem — check 'sv status hive-sync'."
+  else
+    # No termux-services available — keep-alive the daemon by hand so the node
+    # still syncs; Termux:Boot (if installed) re-launches it on reboot.
+    warn "termux-services (sv) unavailable — falling back to a nohup keep-alive (no auto-respawn)."
+    mkdir -p "$HOME/.hive-mind/logs"
+    pkill -f sync_daemon.py 2>/dev/null || true
+    nohup python3 "$HIVE_DIR/sync_daemon.py" >> "$HOME/.hive-mind/logs/hive-sync.log" 2>&1 &
+  fi
+
 elif [[ "$INIT_SYSTEM" == "systemctl" || "$INIT_SYSTEM" == "systemd" ]]; then
   # Hardened daemon unit + self-heal timer (see scripts/installer/_units.sh).
   write_systemd_units "$HIVE_DIR" "$SERVICE_NAME"
@@ -482,6 +563,10 @@ step "9/$TOTAL  Start sync daemon"
 
 if [[ "$INIT_SYSTEM" == "launchd" ]]; then
   launchd_restart "$SERVICE_NAME"
+elif [[ "$INIT_SYSTEM" == "runit" ]]; then
+  if command -v sv >/dev/null 2>&1; then
+    runit_restart "$SERVICE_NAME"
+  fi   # else: the step-8 nohup fallback already started it
 elif [[ "$INIT_SYSTEM" == "systemctl" || "$INIT_SYSTEM" == "systemd" ]]; then
   systemctl --user restart "$SERVICE_NAME"
 elif [[ "$INIT_SYSTEM" == "initd" ]]; then
@@ -497,6 +582,8 @@ HELLO=$(curl -sf "http://127.0.0.1:9876/sync/hello" 2>/dev/null) && {
 } || {
   if [[ "$INIT_SYSTEM" == "launchd" ]]; then
     warn "Daemon not yet responding on :9876. Check: ~/Library/Logs/hive-mind/hive-sync.log"
+  elif [[ "$INIT_SYSTEM" == "runit" ]]; then
+    warn "Daemon not yet responding on :9876. Check: ~/.hive-mind/logs/hive-sync.log  (and: sv status hive-sync)"
   else
     warn "Daemon not yet responding on :9876. Check: journalctl --user -u $SERVICE_NAME -n 20"
   fi
@@ -591,6 +678,9 @@ echo "  Data:    $HIVE_DIR"
 if [[ "$INIT_SYSTEM" == "launchd" ]]; then
   echo "  Daemon:  launchctl print gui/\$(id -u)/com.projectmentor.hive-sync"
   echo "  Logs:    ~/Library/Logs/hive-mind/hive-sync.log"
+elif [[ "$INIT_SYSTEM" == "runit" ]]; then
+  echo "  Daemon:  sv status hive-sync"
+  echo "  Logs:    ~/.hive-mind/logs/hive-sync.log"
 else
   echo "  Daemon:  systemctl --user status $SERVICE_NAME"
   echo "  Logs:    journalctl --user -u $SERVICE_NAME -f"

--- a/scripts/installer/_runit.sh
+++ b/scripts/installer/_runit.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# =============================================================================
+# _runit.sh — Android/Termux (termux-services / runit) backend for the supervisor.
+#
+# The Termux analogue of _units.sh (systemd) and _launchd.sh (launchd). Sourced
+# by _service.sh only on Android. Termux has no systemd, launchd, cron, sudo, or
+# root — its standard supervisor is termux-services, which runs `runsvdir` over
+# $PREFIX/var/service. Each service is a directory with an executable `run`
+# script; `sv up|down|restart|status <name>` controls it; `sv-enable`/`sv-disable`
+# toggle auto-start. runit has NO timers, so the periodic self-heal is a `run`
+# script that loops `hv doctor --fix; sleep 900` (≙ hive-doctor.timer 15-min).
+#
+#   hive-sync    runsvdir respawn-on-exit  ≙ systemd Restart=always / launchd KeepAlive
+#   hive-doctor  while-loop every 900s      ≙ hive-doctor.timer OnUnitActiveSec=15min
+#
+# A phone behind Tailscale's userspace VPN cannot accept inbound :9876, but it
+# never needs to: sync_daemon.py's run_daemon() does an OUTBOUND sync_now() every
+# 300s, which both pulls and pushes — so the supervised daemon converges the node
+# on its own. A Termux:Boot entrypoint (~/.termux/boot/) restarts it on reboot.
+#
+# All paths are overridable for tests / CI (see _runit_render + --render-test):
+# the render path needs no device, no `sv`, and runs on an ordinary Linux runner.
+# =============================================================================
+
+# Termux's $PREFIX is /data/data/com.termux/files/usr; fall back to it for CI
+# (where PREFIX is unset) so the rendered paths still resemble a real device.
+_RUNIT_PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+_RUNIT_SERVICE_DIR="${_RUNIT_SERVICE_DIR:-$_RUNIT_PREFIX/var/service}"
+_RUNIT_LOG_DIR="${_RUNIT_LOG_DIR:-$HOME/.hive-mind/logs}"
+_RUNIT_BOOT_DIR="${_RUNIT_BOOT_DIR:-$HOME/.termux/boot}"
+
+# Best interpreter for the run scripts: PATH first, then the Termux prefix.
+_runit_python3() {
+  if command -v python3 >/dev/null 2>&1; then command -v python3; return; fi
+  echo "$_RUNIT_PREFIX/bin/python3"
+}
+
+# A run script needs a real shebang. Use the Termux sh if present, else /bin/sh
+# (CI / render-test on an ordinary Linux runner has no Termux prefix).
+_runit_sh() {
+  [ -x "$_RUNIT_PREFIX/bin/sh" ] && { echo "$_RUNIT_PREFIX/bin/sh"; return; }
+  echo /bin/sh
+}
+
+# _runit_render <hive_dir> — write the two service `run` scripts + the Termux:Boot
+# entrypoint, no `sv`. Split out (like _launchd_render) so CI can render + lint
+# without termux-services or a phone.
+_runit_render() {
+  local hive_dir="$1" py sh svc_run doctor_run boot
+  if [ -z "$hive_dir" ] || [ ! -f "$hive_dir/sync_daemon.py" ]; then
+    echo "_runit_render: invalid hive_dir '$hive_dir' (no sync_daemon.py)" >&2
+    return 1
+  fi
+  py="$(_runit_python3)"; sh="$(_runit_sh)"
+  mkdir -p "$_RUNIT_SERVICE_DIR/hive-sync" "$_RUNIT_SERVICE_DIR/hive-doctor" \
+           "$_RUNIT_LOG_DIR" "$_RUNIT_BOOT_DIR"
+
+  # ── the sync daemon: runsvdir respawns it on exit (≙ Restart=always) ──
+  svc_run="$_RUNIT_SERVICE_DIR/hive-sync/run"
+  cat > "$svc_run" << RUN
+#!$sh
+# hive-mind sync daemon (runit-supervised; runsvdir respawns on exit).
+# run_daemon() serves :9876 AND syncs outbound every 300s — converges this node.
+export HIVE_HOME="$hive_dir"
+cd "$hive_dir" || exit 1
+exec "$py" "$hive_dir/sync_daemon.py" >> "$_RUNIT_LOG_DIR/hive-sync.log" 2>&1
+RUN
+
+  # ── self-heal: `hv doctor --fix` on a 900s loop (runit has no timers) ──
+  doctor_run="$_RUNIT_SERVICE_DIR/hive-doctor/run"
+  cat > "$doctor_run" << RUN
+#!$sh
+# hive-mind self-heal — runit has no timers, so loop hv doctor --fix every 15 min.
+export HIVE_HOME="$hive_dir"
+cd "$hive_dir" || exit 1
+while :; do
+  "$py" "$hive_dir/hv" doctor --fix >> "$_RUNIT_LOG_DIR/hive-doctor.log" 2>&1
+  sleep 900
+done
+RUN
+
+  # ── Termux:Boot entrypoint: start on phone reboot (app must be installed) ──
+  boot="$_RUNIT_BOOT_DIR/start-hive-mind"
+  cat > "$boot" << BOOT
+#!$sh
+# Termux:Boot entrypoint — start hive-mind on phone reboot. Keep this executable.
+# Requires the Termux:Boot app (F-Droid), opened once, with battery optimisation
+# disabled for Termux + Termux:Boot. A wakelock keeps Android Doze from freezing
+# the daemon.
+termux-wake-lock 2>/dev/null || true
+# Start the runit supervisor tree if termux-services' login hook hasn't already.
+if [ -x "$_RUNIT_PREFIX/etc/profile.d/start-services.sh" ]; then
+  . "$_RUNIT_PREFIX/etc/profile.d/start-services.sh"
+elif ! pgrep -x runsvdir >/dev/null 2>&1; then
+  runsvdir "$_RUNIT_SERVICE_DIR" &
+fi
+sleep 2
+sv up hive-sync   2>/dev/null || true
+sv up hive-doctor 2>/dev/null || true
+BOOT
+
+  chmod +x "$svc_run" "$doctor_run" "$boot"
+}
+
+# runit_install <hive_dir> [svc] — render the scripts then enable + start both
+# services. The svc arg is accepted for signature parity with write_systemd_units
+# / launchd_install; the service names are fixed (hive-sync, hive-doctor).
+runit_install() {
+  local hive_dir="$1" label
+  _runit_render "$hive_dir" || return 1
+  # Lint the generated run scripts before handing them to runsvdir.
+  for label in hive-sync hive-doctor; do
+    sh -n "$_RUNIT_SERVICE_DIR/$label/run" 2>/dev/null \
+      || { echo "runit_install: malformed run script for $label" >&2; return 1; }
+  done
+  if command -v sv-enable >/dev/null 2>&1; then
+    sv-enable hive-sync   2>/dev/null || true
+    sv-enable hive-doctor 2>/dev/null || true
+  fi
+  # `sv up` is idempotent; runsvdir picks up new service dirs within ~5s.
+  sv up hive-sync   2>/dev/null || true
+  sv up hive-doctor 2>/dev/null || true
+}
+
+# runit_restart [svc] — restart the named service (default hive-sync).
+runit_restart() {
+  sv restart "${1:-hive-sync}" 2>/dev/null || true
+}
+
+# runit_is_active [svc] — 0 if runsvdir reports the service running, else 1.
+runit_is_active() {
+  sv status "${1:-hive-sync}" 2>/dev/null | grep -q '^run:'
+}
+
+# runit_uninstall [svc] — stop, disable, and remove both services + the boot
+# script (idempotent; svc arg ignored — labels are fixed).
+runit_uninstall() {
+  local label
+  for label in hive-sync hive-doctor; do
+    sv down "$label"     2>/dev/null || true
+    sv-disable "$label"  2>/dev/null || true
+    rm -rf "$_RUNIT_SERVICE_DIR/$label"
+  done
+  rm -f "$_RUNIT_BOOT_DIR/start-hive-mind"
+}
+
+# `bash _runit.sh --render-test` — render the scripts to a temp tree and lint them.
+# Used by CI on an ordinary Linux runner (no termux-services, no phone): validates
+# the templates without `sv`. Only fires when executed directly, never when sourced.
+if [ "${BASH_SOURCE[0]:-x}" = "${0:-y}" ] && [ "${1:-}" = "--render-test" ]; then
+  set -e
+  _tmp="$(mktemp -d)"
+  _RUNIT_SERVICE_DIR="$_tmp/service"
+  _RUNIT_LOG_DIR="$_tmp/logs"
+  _RUNIT_BOOT_DIR="$_tmp/boot"
+  _repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  _runit_render "$_repo"
+  for _f in "$_RUNIT_SERVICE_DIR/hive-sync/run" "$_RUNIT_SERVICE_DIR/hive-doctor/run" \
+            "$_RUNIT_BOOT_DIR/start-hive-mind"; do
+    echo "lint: $_f"
+    [ -x "$_f" ] || { echo "render-test FAIL: $_f not executable" >&2; exit 1; }
+    sh -n "$_f"  || { echo "render-test FAIL: $_f has a syntax error" >&2; exit 1; }
+  done
+  grep -q 'exec .*sync_daemon.py'  "$_RUNIT_SERVICE_DIR/hive-sync/run"   || { echo "render-test FAIL: hive-sync missing daemon exec" >&2; exit 1; }
+  grep -q 'doctor --fix'           "$_RUNIT_SERVICE_DIR/hive-doctor/run" || { echo "render-test FAIL: hive-doctor missing doctor --fix" >&2; exit 1; }
+  grep -q 'sv up hive-sync'        "$_RUNIT_BOOT_DIR/start-hive-mind"    || { echo "render-test FAIL: boot script missing sv up" >&2; exit 1; }
+  echo "render-test OK"
+fi

--- a/scripts/installer/_service.sh
+++ b/scripts/installer/_service.sh
@@ -7,6 +7,9 @@
 #                 truth, sourced and called VERBATIM here, so the Linux path is
 #                 byte-identical and carries zero regression risk).
 #   macOS       : launchd LaunchAgents  (see _launchd.sh).
+#   Android     : termux-services / runit  (see _runit.sh). Termux has no
+#                 systemd/launchd; `uname -s` reports Linux there, so the kind
+#                 probe matches Android BEFORE falling through to systemd.
 #
 # Callers ask `_service_kind` / the `service_*` wrappers instead of hard-coding
 # `systemctl`. The systemd branch delegates to the existing functions/commands,
@@ -20,13 +23,22 @@ _SERVICE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # systemd unit writer (Linux) — always available; a no-op when no user systemd bus.
 if [ -f "$_SERVICE_LIB_DIR/_units.sh" ]; then . "$_SERVICE_LIB_DIR/_units.sh"; fi
 
-# launchd: the supervisor key. `systemd` covers native Linux + WSL (where the
-# concrete init may be systemctl/systemd/initd/cron — those sub-variants are
-# handled by the installer, not here).
+# launchd: the supervisor key on macOS. runit: Android/Termux. `systemd` covers
+# native Linux + WSL (where the concrete init may be systemctl/systemd/initd/cron
+# — those sub-variants are handled by the installer, not here). Termux reports
+# `uname -s`=Linux, so Android is matched first in the non-Darwin arm via
+# `uname -o`=Android / $TERMUX_VERSION / the Termux data dir. $TERMUX_VERSION also
+# lets CI force the runit branch on an ordinary Linux runner.
 _service_kind() {
   case "$(uname -s)" in
     Darwin) echo launchd ;;
-    *)      echo systemd ;;
+    *)
+      if [ "$(uname -o 2>/dev/null)" = "Android" ] || [ -n "${TERMUX_VERSION:-}" ] \
+         || [ -d /data/data/com.termux ]; then
+        echo runit
+      else
+        echo systemd
+      fi ;;
   esac
 }
 
@@ -35,10 +47,16 @@ if [ "$(_service_kind)" = launchd ] && [ -f "$_SERVICE_LIB_DIR/_launchd.sh" ]; t
   . "$_SERVICE_LIB_DIR/_launchd.sh"
 fi
 
+# Pull in the runit backend only on Android/Termux (defines runit_*).
+if [ "$(_service_kind)" = runit ] && [ -f "$_SERVICE_LIB_DIR/_runit.sh" ]; then
+  . "$_SERVICE_LIB_DIR/_runit.sh"
+fi
+
 # service_install <hive_dir> [svc] — install + enable the supervisor units.
 service_install() {
   case "$(_service_kind)" in
     launchd) launchd_install "$@" ;;
+    runit)   runit_install "$@" ;;
     *)       write_systemd_units "$@" ;;
   esac
 }
@@ -48,6 +66,7 @@ service_restart() {
   local svc="${1:-hive-sync}"
   case "$(_service_kind)" in
     launchd) launchd_restart "$svc" ;;
+    runit)   runit_restart "$svc" ;;
     *)       systemctl --user restart "$svc" 2>/dev/null || true ;;
   esac
 }
@@ -57,6 +76,7 @@ service_is_active() {
   local svc="${1:-hive-sync}"
   case "$(_service_kind)" in
     launchd) launchd_is_active "$svc" ;;
+    runit)   runit_is_active "$svc" ;;
     *)       systemctl --user is-active "$svc" --quiet 2>/dev/null ;;
   esac
 }

--- a/scripts/installer/_uninstall.sh
+++ b/scripts/installer/_uninstall.sh
@@ -73,6 +73,18 @@ if [ "$(uname -s)" = "Darwin" ]; then
     rm -f "$HOME/Library/LaunchAgents/com.projectmentor.$_l.plist"
   done
   [ -z "${HIVE_UNINSTALL_TEST:-}" ] && pkill -f "sync_daemon.py" 2>/dev/null || true
+elif [ "$(uname -o 2>/dev/null)" = "Android" ] || [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux ]; then
+  # Android/Termux runit: stop + disable both services, remove their dirs + the
+  # Termux:Boot entrypoint. Inlined (like the macOS arm) so uninstall stays
+  # self-contained and need not source the supervisor backend.
+  _RUNIT_SVC_DIR="${PREFIX:-/data/data/com.termux/files/usr}/var/service"
+  for _l in hive-sync hive-doctor; do
+    sv down "$_l"    2>/dev/null || true
+    sv-disable "$_l" 2>/dev/null || true
+    rm -rf "$_RUNIT_SVC_DIR/$_l"
+  done
+  rm -f "$HOME/.termux/boot/start-hive-mind"
+  [ -z "${HIVE_UNINSTALL_TEST:-}" ] && pkill -f "sync_daemon.py" 2>/dev/null || true
 else
   systemctl --user disable --now hive-doctor.timer 2>/dev/null || true
   systemctl --user stop hive-doctor.service        2>/dev/null || true
@@ -124,6 +136,7 @@ PY
 fi
 rm -rf "$HOME/.claude/skills/hive-memory" 2>/dev/null || true
 rm -f /tmp/hive-sync.log 2>/dev/null || true
+rm -rf "$HOME/.hive-mind/logs" 2>/dev/null || true   # Android/Termux daemon logs
 
 # ── 4. Identity + Hive data ──────────────────────────────────────────────────
 # Preserve the device IDENTITY (to the stable stash) whenever the user asked to keep anything, so

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -46,11 +46,14 @@ echo -e "${BLD}hive-mind installer${RST}"
 echo "────────────────────────────────────────────"
 echo ""
 
-# ── guard: supported OS (Linux native, WSL2 on Windows 11, or macOS) ────────
+# ── guard: supported OS (Linux native, WSL2 on Windows 11, macOS, Android/Termux) ──
+# Android/Termux reports `uname -s`=Linux, so it falls through the permissive Linux
+# arm here; `hive-mind install` (_install_node.sh) then detects Termux and branches
+# the supervisor (termux-services/runit) + deps (pkg/pip). git/bash come from `pkg`.
 case "$(uname -s)" in
-  Linux)  : ;;   # native Linux, or WSL2 on Windows 11 — both fine
+  Linux)  : ;;   # native Linux, WSL2 on Windows 11, or Android/Termux — all fine
   Darwin) : ;;   # macOS
-  *)      die "Unsupported OS: $(uname -s). HiveMind supports Linux, WSL2, and macOS." ;;
+  *)      die "Unsupported OS: $(uname -s). HiveMind supports Linux, WSL2, macOS, and Android (Termux)." ;;
 esac
 
 # ── 1. ensure ~/.local/bin exists and is on PATH ───────────────────────────


### PR DESCRIPTION
## What

Makes **Android (Termux)** a first-class auto-installed native peer, mirroring the existing macOS/launchd seam. The `hv` core already runs native on Termux, so this is purely installer + supervisor plumbing — **no journal/wire change, no `CONTRACT_VERSION` bump** (same shape as the macOS PR #14).

## Why

A phone running Termux + `pkg install python git` + `pip install requests` already runs the core and syncs to the tailnet, but the install was fully manual — `hive-mind install` only knew Linux/WSL2/macOS. This wires Android into the OS-shimmed installer so a phone joins with one command like every other node.

Key insight: a phone behind Tailscale's userspace VPN **never needs inbound `:9876`**. `sync_daemon.py`'s `run_daemon()` serves locally *and* runs an outbound `sync_now()` every 300s (pull + push), so the supervised daemon converges the node on its own.

## Changes

- **`scripts/installer/_runit.sh`** (new) — termux-services/runit backend mirroring `_launchd.sh`: renders a `hive-sync` run script (runsvdir respawn ≙ `Restart=always`), a `hive-doctor` run script (`while … sleep 900` ≙ `hive-doctor.timer`, since runit has no timers), and a **Termux:Boot** entrypoint (`~/.termux/boot`, `termux-wake-lock`). `runit_install/restart/is_active/uninstall` + a `--render-test` self-test that runs on an ordinary Linux runner.
- **`_service.sh`** — `_service_kind()` returns `runit` on Android (`uname -o`=Android / `$TERMUX_VERSION` / Termux data dir), matched before the systemd default; sources `_runit.sh`; dispatches the `service_*` wrappers.
- **`_install_node.sh`** — `IS_ANDROID` + `INIT_SYSTEM=runit` matched first (before the systemctl/PID-1/loginctl probes Termux lacks); termux-services install + Termux:Boot prompt; Tailscale-is-the-app step (best-effort `100.x` discovery, graceful skip); `pkg`/`pip` deps with `uv` skipped; runit arms in steps 8/9/13; `nohup` keep-alive fallback when `sv` is unavailable.
- **`_uninstall.sh`** — inline runit teardown (`sv down`/`sv-disable`, remove service dirs + boot script) + Android log cleanup.
- **`hv`** — `doctor --fix` restarts the runit `hive-sync` service on Termux for parity.
- **`.github/workflows/ci.yml`** — `android-installer-smoke` job (render-test; `_service_kind`=runit under `TERMUX_VERSION`; systemd-on-Linux no-regression; idempotent uninstall).
- **`README.md` / `docs/CLI_REFERENCE.md`** — Android now supported (was "in progress"); supervisor commands + Termux setup notes; platform lists kept alphabetical.

## Verification

- `bash -n` on all 5 installer scripts ✓, `hv` parses ✓
- `_runit.sh --render-test` green ✓ (run scripts + boot script lint + executable)
- `_service_kind` matrix: `runit` under Termux env, `systemd` on plain Linux (no regression) ✓
- `runit_uninstall` idempotent ✓
- Offline suite: **205 passed**

What CI can't prove (needs a real phone, same caveat as the macOS job): `sv`/runsvdir actually supervise the daemon, Termux:Boot fires on reboot, real app-owned Tailscale tun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)