### PR TITLE
feat(install): hive-mind invite + seed-peer join for Android (+ $USER crash fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,30 @@ jobs:
         run: bash -c '. scripts/installer/_service.sh; [ "$(_service_kind)" = systemd ]'
       - name: runit_uninstall is idempotent
         run: TERMUX_VERSION=1 bash -c '. scripts/installer/_service.sh; runit_uninstall hive-sync; runit_uninstall hive-sync'
+      - name: installer scripts lint clean (bash -n)
+        run: |
+          for f in install.sh _install_node.sh _service.sh _runit.sh _invite.sh _uninstall.sh _update.sh _status.sh dispatcher.sh; do
+            bash -n "scripts/installer/$f"
+          done
+      - name: hive-mind invite runs + dispatcher routes it
+        run: |
+          bash scripts/installer/_invite.sh >/dev/null          # exits 0 even with no tailscale (warns)
+          bash scripts/installer/dispatcher.sh help | grep -q 'invite'
+      - name: seed-address parser strips scheme/user/path, rejects junk
+        run: |
+          python3 - <<'PY'
+          import re
+          def parse(s):
+              s=s.strip(); s=re.sub(r'^[a-zA-Z][a-zA-Z0-9+.-]*://','',s)
+              if '@' in s: s=s.split('@',1)[1]
+              s=s.split('/',1)[0]; host,port=s,'9876'
+              if ':' in s: host,port=s.rsplit(':',1)
+              host=host.strip(); port=(port.strip() or '9876')
+              return f'{host} {port}' if host and re.match(r'^[A-Za-z0-9._-]+$',host) and port.isdigit() else ''
+          assert parse('100.84.84.100')=='100.84.84.100 9876'
+          assert parse('david@100.84.84.100:9876')=='100.84.84.100 9876'
+          assert parse('http://100.84.84.100:9876/sync')=='100.84.84.100 9876'
+          assert parse('garbage here')==''
+          assert parse('')==''
+          print('seed-parse OK')
+          PY

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Connect the Tailscale Android app before syncing. A phone behind Tailscale's use
 can't accept inbound connections, but it doesn't need to: it converges by syncing outbound
 every 5 minutes.
 
+**Joining an existing hive from the phone.** Android has no `tailscale` CLI (Tailscale is the
+app), so the installer can't auto-discover hives on the tailnet. Instead, on a device that's
+already in the hive run `hive-mind invite` — it prints one line (that device's Tailscale
+address). Paste it when the phone's `hive-mind install` asks for a hive address. You only need
+one node to join; everything else syncs from there. Then admit the phone from the owner:
+`hv group admit <phone-device-id> --principal <you>`.
+
 </details>
 
 <details>

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -830,7 +830,25 @@ hive-mind <subcommand> [options]
 | `install` | Set up this device from scratch (discovery-driven bootstrap or join). |
 | `update` | Pull the latest code and restart the sync daemon. |
 | `status` | Show device health and peer sync state. |
+| `invite` | Print the one-line address to paste on a new device so it can join this hive. |
 | `uninstall` | Remove HiveMind from this device (see flags below). |
+
+### `hive-mind invite` — add another device
+
+```bash
+hive-mind invite
+```
+
+Run it on any device that's **already in the hive**; its only output is this node's Tailscale
+address (e.g. `100.84.84.100`). On the **new** device, run `hive-mind install` and paste that
+line when it asks for a hive address — no need to know what an IP is or where to find it.
+
+`hive-mind install` auto-discovers hives on platforms with the `tailscale` CLI (Linux, macOS,
+WSL). On **Android (Termux)** there is no `tailscale` CLI — Tailscale is the phone's VPN app —
+so discovery can't enumerate the tailnet; the installer asks you to paste an address instead.
+You only ever need **one** node of the hive to join; the rest syncs from there. (A fresh
+`hive-mind install` on the owner device prints the invite line automatically once the hive is
+created.)
 
 ### `hive-mind uninstall`
 

--- a/scripts/installer/_install_node.sh
+++ b/scripts/installer/_install_node.sh
@@ -43,6 +43,11 @@ case ":$PATH:" in *":$HOME/.local/bin:"*) BIN_ON_PATH=1 ;; *) BIN_ON_PATH="" ;; 
 _SVCLIB="$HIVE_DIR/scripts/installer/_service.sh"
 if [ -f "$_SVCLIB" ]; then . "$_SVCLIB"; fi
 
+# Safe username. Termux does NOT export $USER, and this script runs `set -u`, so a
+# bare $USER (principal default, the SSH summary line) aborts with "unbound variable".
+# Resolve it once, with fallbacks that exist on Termux too.
+THIS_USER="${USER:-$(id -un 2>/dev/null || whoami 2>/dev/null || echo user)}"
+
 # ── colours ────────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GRN='\033[0;32m'; YLW='\033[1;33m'; CYN='\033[0;36m'; BLD='\033[1m'; RST='\033[0m'
 ok()   { echo -e "${GRN}[ok]${RST}  $*"; }
@@ -91,10 +96,10 @@ elif [ -n "$IS_MAC" ]; then
   INIT_SYSTEM="launchd"
 elif command -v systemctl &>/dev/null; then
   INIT_SYSTEM="systemctl"
-  loginctl enable-linger "$USER" 2>/dev/null || true
+  loginctl enable-linger "$THIS_USER" 2>/dev/null || true
 elif [[ "$(ps -p 1 -o comm= 2>/dev/null | tr -d '[:space:]')" == "systemd" ]]; then
   INIT_SYSTEM="systemd"
-  loginctl enable-linger "$USER" 2>/dev/null || true
+  loginctl enable-linger "$THIS_USER" 2>/dev/null || true
 elif [ -d /etc/init.d ]; then
   INIT_SYSTEM="initd"
 fi
@@ -441,7 +446,7 @@ else
   [ -n "$HIVES_JSON" ] || HIVES_JSON='[]'
   HIVE_COUNT=$(printf '%s' "$HIVES_JSON" | python3 -c "import sys,json;print(len(json.loads(sys.stdin.read() or '[]')))" 2>/dev/null || echo 0)
 
-  CHOICE="n"
+  CHOICE="n"; SEED_HOST=""; SEED_PORT="9876"; JOIN_ATTEMPTED=""
   if [ "${HIVE_COUNT:-0}" -gt 0 ]; then
     echo ""
     echo "  Found $HIVE_COUNT hive(s) on your tailnet:"
@@ -453,28 +458,93 @@ for i,h in enumerate(json.loads(sys.stdin.read())):
     ask "Join which hive? (number, or 'n' for a new hive): "
     read -r CHOICE
   else
-    ok "No existing hive found on the tailnet."
+    # Nothing auto-discovered. On Android this is EXPECTED and permanent: `hv discover`
+    # enumerates the tailnet via the `tailscale` CLI, which Termux doesn't have (Tailscale
+    # is the phone's VPN app). Rather than silently start a brand-new hive (the wrong
+    # default for someone who meant to JOIN), offer to join by pasting an address — you
+    # only need ONE node of an existing hive to get in.
+    if [ -n "$IS_ANDROID" ]; then
+      info "No hive auto-discovered. (On Android, discovery can't scan the tailnet — Tailscale is the app, with no CLI in Termux.)"
+    else
+      info "No hive auto-discovered on the tailnet."
+    fi
+    if [ -t 0 ]; then
+      echo "  To JOIN your existing hive, paste its address below."
+      echo -e "  Get it by running  ${BLD}hive-mind invite${RST}  on a device that's already in the hive."
+      echo "  (Or just press Enter to start a NEW hive on this device.)"
+      _tries=0
+      while [ "$_tries" -lt 3 ]; do
+        ask "Hive address to join (paste, or Enter for a new hive): "
+        read -r _ADDR
+        [ -z "$_ADDR" ] && break        # explicit Enter → bootstrap a new hive
+        JOIN_ATTEMPTED=1
+        # Forgiving parse: accept IP, ip:port, name@ip:port, http://ip:port/..., or a host.
+        _PARSED=$(python3 -c "
+import sys,re
+s=sys.argv[1].strip()
+s=re.sub(r'^[a-zA-Z][a-zA-Z0-9+.-]*://','',s)   # strip scheme
+if '@' in s: s=s.split('@',1)[1]                # strip user@
+s=s.split('/',1)[0]                             # strip path
+host,port=s,'9876'
+if ':' in s: host,port=s.rsplit(':',1)
+host=host.strip(); port=(port.strip() or '9876')
+print(f'{host} {port}' if host and re.match(r'^[A-Za-z0-9._-]+\$',host) and port.isdigit() else '')
+" "$_ADDR" 2>/dev/null)
+        SEED_HOST=$(echo "$_PARSED" | awk '{print $1}'); SEED_PORT=$(echo "$_PARSED" | awk '{print $2}')
+        SEED_PORT="${SEED_PORT:-9876}"
+        if [ -z "$SEED_HOST" ]; then
+          warn "Couldn't read an address from that. Paste just the line that 'hive-mind invite' prints."
+          _tries=$((_tries + 1)); continue
+        fi
+        info "Checking for a hive at $SEED_HOST:$SEED_PORT ..."
+        if curl -sf -m 8 "http://$SEED_HOST:${SEED_PORT}/hive/info" >/dev/null 2>&1; then
+          ok "Found a hive at $SEED_HOST:$SEED_PORT."
+          break
+        fi
+        warn "No hive answered at $SEED_HOST:$SEED_PORT — that device may be off, or it's a typo. Try again."
+        _tries=$((_tries + 1))   # keep SEED_HOST as the last candidate in case it's just temporarily down
+      done
+    fi
   fi
 
-  if [ "$CHOICE" = "n" ] || [ "$CHOICE" = "N" ] || [ -z "$CHOICE" ]; then
+  # Resolve the JOIN target: a pasted seed address wins; else a numbered discover choice.
+  PEER_IP=""; PEER_PORT="9876"
+  if [ -n "$SEED_HOST" ]; then
+    PEER_IP="$SEED_HOST"; PEER_PORT="$SEED_PORT"
+  elif [ "$CHOICE" != "n" ] && [ "$CHOICE" != "N" ] && [ -n "$CHOICE" ]; then
+    PEER=$(printf '%s' "$HIVES_JSON" | python3 -c "import sys,json;hs=json.loads(sys.stdin.read());i=int('$CHOICE')-1;h=hs[i];print(h['ip'],h['port'])" 2>/dev/null)
+    PEER_IP=$(echo "$PEER" | awk '{print $1}'); PEER_PORT=$(echo "$PEER" | awk '{print $2}')
+    [ -n "$PEER_IP" ] || die "Invalid choice '$CHOICE'."
+  fi
+
+  # A failed join attempt must NOT silently fall through to creating a new hive — that's
+  # exactly the trap that put a phone on its own island. Only an explicit Enter bootstraps.
+  if [ -z "$PEER_IP" ] && [ -n "$JOIN_ATTEMPTED" ]; then
+    die "Couldn't read a hive address to join. Run 'hive-mind invite' on a device already in your hive to get the exact line to paste, then re-run 'hive-mind install'. (Not starting a new hive, since you meant to join one.)"
+  fi
+
+  if [ -z "$PEER_IP" ]; then
     # ── Bootstrap: become the owner (queen bee) ──
     ask "Your name (principal tag for your devices): "
-    read -r PRINCIPAL; PRINCIPAL="${PRINCIPAL:-$USER}"
+    read -r PRINCIPAL; PRINCIPAL="${PRINCIPAL:-$THIS_USER}"
     python3 -c "import json,sys;json.dump({'self':sys.argv[1],'bind':'0.0.0.0','port':9876,'peers':[]},open(sys.argv[2],'w'),indent=2)" "$THIS_DEVICE" "$PEERS_FILE"
     ./hv owner init >/dev/null && ok "New hive created — you are the queen bee!"
     ./hv group admit "$THIS_DEVICE" --principal "$PRINCIPAL" >/dev/null && ok "Admitted this device (principal: $PRINCIPAL)."
     ok "hive_id: $(./hv owner show 2>/dev/null | awk '/hive_id:/{print $2}')"
+    # Surface the invite right where a hive is born, so the owner knows exactly what to
+    # paste on their other devices to add them — no "how do I get the address?" round-trip.
+    if [ -f "$HIVE_DIR/scripts/installer/_invite.sh" ]; then
+      echo ""
+      HIVE_DIR="$HIVE_DIR" bash "$HIVE_DIR/scripts/installer/_invite.sh" 2>/dev/null || true
+    fi
   else
-    # ── Join: configure the chosen hive's node as a peer, sync, request admission ──
-    PEER=$(printf '%s' "$HIVES_JSON" | python3 -c "import sys,json;hs=json.loads(sys.stdin.read());i=int('$CHOICE')-1;h=hs[i];print(h['ip'],h['port'])" 2>/dev/null)
-    PEER_IP=$(echo "$PEER" | awk '{print $1}'); PEER_PORT=$(echo "$PEER" | awk '{print $2}')
-    [ -n "$PEER_IP" ] || die "Invalid choice '$CHOICE'."
+    # ── Join: configure the chosen/pasted hive node as a peer, sync, request admission ──
     python3 -c "import json,sys;json.dump({'self':sys.argv[1],'bind':'0.0.0.0','port':9876,'peers':[{'id':sys.argv[2].replace('.','-'),'url':'http://'+sys.argv[2]+':'+sys.argv[3]}]},open(sys.argv[4],'w'),indent=2)" "$THIS_DEVICE" "$PEER_IP" "$PEER_PORT" "$PEERS_FILE"
     ok "Peer configured: $PEER_IP:$PEER_PORT"
     info "Syncing the hive (pulling its journal + owner declaration)..."
     ./hv sync now >/dev/null 2>&1 || true
     ask "Your name (the principal you'd like to be admitted as): "
-    read -r PRINCIPAL; PRINCIPAL="${PRINCIPAL:-$USER}"
+    read -r PRINCIPAL; PRINCIPAL="${PRINCIPAL:-$THIS_USER}"
     ./hv join --principal "$PRINCIPAL" 2>/dev/null || true
     warn "You're syncing the hive but NOT yet admitted — your writes won't count until the owner admits you."
     echo "  Ask the hive's owner to run:  hv group admit $THIS_DEVICE --principal $PRINCIPAL"
@@ -689,8 +759,14 @@ echo "  Try:     hv stats   (health check: hv doctor)"
 [ -z "$BIN_ON_PATH" ] && \
   echo "           ↳ new terminals work automatically; for THIS shell once: source ~/.bashrc"
 echo ""
-echo "  SSH to this device from any peer:"
-echo "    tailscale ssh ${USER}@${THIS_IP}"
+if [ -n "$IS_ANDROID" ]; then
+  echo "  Add another device to this hive:"
+  echo "    hive-mind invite      (prints the address to paste during its install)"
+else
+  echo "  SSH to this device from any peer:"
+  echo "    tailscale ssh ${THIS_USER}@${THIS_IP}"
+  echo "  Add another device to this hive:  hive-mind invite"
+fi
 echo ""
 
 if [ -f "$PEERS_FILE" ]; then

--- a/scripts/installer/_invite.sh
+++ b/scripts/installer/_invite.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hive-mind invite  —  scripts/installer/_invite.sh
+#
+# Prints the ONE line a new device needs to join this hive: this node's Tailscale
+# address. The whole point is to make "how do I get the address?" a single command
+# with copy-paste output — no networking knowledge required. The new device pastes
+# it at the `hive-mind install` join prompt.
+#
+# Resolving our own tailnet IP is cross-platform: the `tailscale` CLI when present
+# (Linux/macOS), else the interface (Android/Termux, where Tailscale is the app and
+# has no CLI — same path STEP 2 of the installer uses), else `hostname -I`.
+#
+# Invoked by: hive-mind invite   |   bash scripts/installer/_invite.sh
+# =============================================================================
+set -uo pipefail
+
+HIVE_DIR="${HIVE_DIR:-$HOME/projects/hive-mind}"
+PORT="${HIVE_SYNC_PORT:-9876}"
+
+GRN='\033[0;32m'; YLW='\033[1;33m'; BLD='\033[1m'; RST='\033[0m'
+warn() { echo -e "${YLW}[!!]${RST}  $*"; }
+
+# macOS app path for the tailscale binary (defines _resolve_tailscale) — best-effort.
+_SVCLIB="$HIVE_DIR/scripts/installer/_service.sh"
+[ -f "$_SVCLIB" ] && . "$_SVCLIB" 2>/dev/null || true
+
+# Resolve THIS device's 100.x tailnet IP, trying the most authoritative source first.
+_tailnet_ip() {
+  local ip=""
+  # 1. tailscale CLI (Linux / macOS with brew CLI)
+  if command -v tailscale >/dev/null 2>&1; then
+    ip="$(tailscale ip -4 2>/dev/null | grep '^100\.' | head -1 | tr -d '[:space:]')"
+    [ -n "$ip" ] && { echo "$ip"; return; }
+  fi
+  # 2. macOS GUI-app tailscale binary
+  if command -v _resolve_tailscale >/dev/null 2>&1; then
+    local tsbin; tsbin="$(_resolve_tailscale 2>/dev/null || true)"
+    if [ -n "$tsbin" ]; then
+      ip="$("$tsbin" ip -4 2>/dev/null | grep '^100\.' | head -1 | tr -d '[:space:]')"
+      [ -n "$ip" ] && { echo "$ip"; return; }
+    fi
+  fi
+  # 3. the interface (Android/Termux app-owned tun, or any node without the CLI)
+  if command -v ip >/dev/null 2>&1; then
+    ip="$(ip -4 addr 2>/dev/null | grep -oE '100\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    [ -n "$ip" ] && { echo "$ip"; return; }
+  fi
+  if command -v ifconfig >/dev/null 2>&1; then
+    ip="$(ifconfig 2>/dev/null | grep -oE '100\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    [ -n "$ip" ] && { echo "$ip"; return; }
+  fi
+  # 4. last resort
+  if command -v hostname >/dev/null 2>&1; then
+    ip="$(hostname -I 2>/dev/null | tr ' ' '\n' | grep '^100\.' | head -1)"
+    [ -n "$ip" ] && { echo "$ip"; return; }
+  fi
+  echo ""
+}
+
+TS_IP="$(_tailnet_ip)"
+HIVE_ID=""
+[ -x "$HIVE_DIR/hv" ] && HIVE_ID="$("$HIVE_DIR/hv" owner show 2>/dev/null | awk '/hive_id:/{print $2}')"
+
+echo ""
+echo -e "${BLD}hive-mind invite${RST}${HIVE_ID:+   (hive $HIVE_ID)}"
+echo "────────────────────────────────────"
+if [ -z "$TS_IP" ]; then
+  warn "Couldn't find this device's Tailscale (100.x) address."
+  warn "Make sure Tailscale is connected, then run 'hive-mind invite' again."
+  exit 0
+fi
+echo "  Add a device to this hive. On the NEW device, run:"
+echo -e "      ${BLD}hive-mind install${RST}"
+echo "  and when it asks for a hive address, paste this:"
+echo ""
+echo -e "      ${GRN}${BLD}${TS_IP}${RST}"
+echo ""
+echo "  (That's this device's Tailscale address — the new device only needs one node to join.)"
+echo ""

--- a/scripts/installer/dispatcher.sh
+++ b/scripts/installer/dispatcher.sh
@@ -31,6 +31,7 @@ case "$CMD" in
   install)   exec bash "$INSTALLER/_install_node.sh" "$@" ;;
   update)    exec bash "$INSTALLER/_update.sh"       "$@" ;;
   status)    exec bash "$INSTALLER/_status.sh"       "$@" ;;
+  invite)    exec bash "$INSTALLER/_invite.sh"       "$@" ;;
   uninstall) exec bash "$INSTALLER/_uninstall.sh"    "$@" ;;
   *)
     echo "Usage: hive-mind <subcommand>"
@@ -39,6 +40,7 @@ case "$CMD" in
     echo "  install      Set up this device from scratch"
     echo "  update       Pull latest + restart daemon"
     echo "  status       Show device health and peer sync state"
+    echo "  invite       Print the address to paste on a new device to join this hive"
     echo "  uninstall    Remove HiveMind from this device (--keep-hive to keep your data)"
     echo ""
     ;;


### PR DESCRIPTION
Follow-up to #17. The Android supervisor seam works; this fixes the two **onboarding** gaps that stranded the test phone on its own hive, plus a crash.

## 1. `hv discover` can't see the tailnet on Android → STEP 6 wrongly bootstrapped a new hive
`hv discover` shells out to the `tailscale` CLI, which Termux doesn't have (Tailscale is the phone's VPN app), so discovery is **always empty** on Android and STEP 6 fell through to creating a brand-new hive — putting the device on its own island (exactly what happened in testing).

Now, when discovery finds nothing, STEP 6 offers to **join by pasting an address**:
- forgiving parse — accepts `100.84.84.100`, `ip:port`, `name@ip:port`, `http://ip:port/…`, or a MagicDNS host;
- validates against `/hive/info` before committing, with a clear retry message;
- a **failed** join attempt no longer falls through to creating a new hive — only an explicit Enter bootstraps.

Auto-discovery is **untouched** on Linux/macOS/WSL; the paste path only triggers when discovery returns nothing.

## 2. `hive-mind invite` — make the address copy-paste, not a scavenger hunt
To keep the paste hassle-free (no "what's an IP / where do I find it?" tickets), add `hive-mind invite`: run it on any device already in the hive and it prints **one line** — that node's Tailscale address — resolved via the CLI, else the interface, else `hostname -I` (so it works on Android too). The owner's fresh `hive-mind install` prints the invite line automatically once the hive is created, so the address is handed to you.

## 3. `$USER` unbound-variable crash
Termux doesn't export `$USER` and the installer runs `set -u`, so the summary's `tailscale ssh $USER@…` line aborted with "unbound variable" (an empty principal would have too). Resolved once into `THIS_USER`; the SSH-to-device summary is now Android-aware (shows the invite hint, since Termux isn't a tailscale-ssh target).

## Verify
bash -n all 9 installer scripts · `_runit.sh --render-test` · `hive-mind invite` runs + exits 0 + dispatcher routes it · seed-address parser (strips scheme/user/path, rejects junk) · offline pytest suite. New CI steps cover all of these. No contract bump (installer/docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)