### PR TITLE
fix(sync): survive sub-1280-MTU tailnet paths (TCP MSS clamp + pagination)

### DIFF
--- a/hive_sync_daemon.py
+++ b/hive_sync_daemon.py
@@ -88,6 +88,7 @@ class Handler(BaseHTTPRequestHandler):
             self.connection.settimeout(SOCKET_TIMEOUT)
         except Exception:
             pass
+        sync_common.clamp_mss(self.connection)   # keep responses under a sub-1280-MTU tailnet ceiling
 
     def log_message(self, fmt, *args):  # keep the daemon quiet; errors go to do_*
         pass
@@ -248,6 +249,7 @@ def make_server(bind=None, port=None):
     for p in range(base, base + 5):
         try:
             srv = ThreadingHTTPServer((bind, p), Handler)
+            sync_common.clamp_mss(srv.socket)   # accepted connections inherit the clamped MSS (Linux)
             if p != base:
                 print(f"sync daemon: :{base} is held by a non-hive service; using :{p}")
                 _persist_port(p)

--- a/sync_client.py
+++ b/sync_client.py
@@ -11,7 +11,11 @@ Runs a bidirectional round with each configured peer:
   4. PUSH the windows the peer lacks/differs on to its /sync/ingest.
 """
 
+import os
+import socket
+
 import requests
+from requests.adapters import HTTPAdapter
 
 import merkle
 import sync_common
@@ -19,19 +23,60 @@ import sync_common
 hv = sync_common.load_hv()
 SIZE = merkle.CHUNK_SIZE
 
+# ── path-MTU resilience (see sync_common.SYNC_MAX_SEG) ────────────────────────────────────────────
+# Two defenses against a sub-1280-MTU tailnet path, both keeping Tailscale at its DEFAULTS:
+#   1. Clamp the outgoing TCP segment size on our connections (covers the PUSH/POST body). Only
+#      where the platform actually allows it — macOS rejects TCP_MAXSEG, and a urllib3 socket_option
+#      that errors would break EVERY connection, so we gate on sync_common.MAXSEG_OK.
+#   2. Paginate PULL and PUSH into small batches so each transfer "catches its breath" — this carries
+#      sync even on platforms where the clamp can't apply.
+PULL_PAGE = max(1, int(os.environ.get("HIVE_SYNC_PULL_PAGE", "25")))   # entries per /sync/chunk GET
+PUSH_PAGE = max(1, int(os.environ.get("HIVE_SYNC_PUSH_PAGE", "25")))   # entries per /sync/ingest POST
+
+
+class _ClampMSSAdapter(HTTPAdapter):
+    """Cap the outgoing TCP segment size on sync connections so multi-KB bodies survive a
+    sub-1280-MTU tailnet path. Adds the socket option ONLY where TCP_MAXSEG is settable
+    (sync_common.MAXSEG_OK) — never on macOS, where it would raise and break the connection."""
+    def init_poolmanager(self, *args, **kwargs):
+        try:
+            from urllib3.connection import HTTPConnection
+            opts = list(HTTPConnection.default_socket_options or [])
+        except Exception:
+            opts = []
+        if sync_common.MAXSEG_OK:
+            opts.append((socket.IPPROTO_TCP, socket.TCP_MAXSEG, sync_common.SYNC_MAX_SEG))
+        kwargs["socket_options"] = opts
+        return super().init_poolmanager(*args, **kwargs)
+
+
+_session = None
+
+
+def _sess():
+    """A shared requests.Session whose connections clamp the TCP segment size where supported."""
+    global _session
+    if _session is None:
+        s = requests.Session()
+        adapter = _ClampMSSAdapter()
+        s.mount("http://", adapter)
+        s.mount("https://", adapter)
+        _session = s
+    return _session
+
 
 def _local_entries():
     return merkle.read_all_entries(hv.JOURNAL_DIR)
 
 
 def _get(base, path, **params):
-    r = requests.get(f"{base}{path}", params=params or None, timeout=15)
+    r = _sess().get(f"{base}{path}", params=params or None, timeout=15)
     r.raise_for_status()
     return r.json()
 
 
 def _post(base, path, payload):
-    r = requests.post(f"{base}{path}", json=payload, timeout=60)
+    r = _sess().post(f"{base}{path}", json=payload, timeout=60)
     r.raise_for_status()
     return r.json()
 
@@ -66,11 +111,19 @@ def _sync_with_peer(peer):
         return
     remote_chunks = hello.get("chunks", {})
 
-    # PULL differing/missing windows from the peer.
+    # PULL differing/missing windows, paginated into PULL_PAGE-seq sub-windows so each /sync/chunk
+    # response stays small (the window is ours to size; the peer chooses nothing). A new entry written
+    # mid-round is simply caught this round if ahead of our cursor, or next round if behind — append
+    # is a G-Set union keyed by (node_id, seq), so re-pulls are no-ops and the Merkle re-check runs
+    # until both sides match. Safe under concurrent writes.
     pulled = []
     for node, start, end in _differing_windows(merkle.node_chunk_hashes(local), remote_chunks):
-        data = _get(base, "/sync/chunk", node=node, start=start, end=end)
-        pulled.extend(data.get("entries", []))
+        s = start
+        while s <= end:
+            e = min(s + PULL_PAGE - 1, end)
+            data = _get(base, "/sync/chunk", node=node, start=s, end=e)
+            pulled.extend(data.get("entries", []))
+            s = e + 1
 
     accepted = duplicates = 0
     if pulled:
@@ -85,8 +138,11 @@ def _sync_with_peer(peer):
         push.extend(merkle.entries_in_range(local, node, start, end))
 
     pushed = 0
-    if push:
-        pushed = _post(base, "/sync/ingest", {"entries": push, "hive_id": local_hive}).get("accepted", 0)
+    # Paginate the push so each /sync/ingest body stays small; the daemon de-dups by (node_id, seq),
+    # so a batch that partially overlaps prior state is idempotent.
+    for i in range(0, len(push), PUSH_PAGE):
+        pushed += _post(base, "/sync/ingest",
+                        {"entries": push[i:i + PUSH_PAGE], "hive_id": local_hive}).get("accepted", 0)
 
     print(f"  {pid}: pulled {accepted} (dup {duplicates}), pushed {pushed}")
 

--- a/sync_common.py
+++ b/sync_common.py
@@ -16,6 +16,48 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 PORT_DEFAULT = 9876
 
+# ── path-MTU resilience (shared by the daemon + client) ──────────────────────────────────────
+# Many tailnets ride an underlay whose effective path MTU is BELOW Tailscale's default 1280, which
+# silently blackholes full-size packets: a small response (/sync/hello) passes, but a multi-KB
+# /sync/chunk or /sync/ingest stalls until the read timeout and peers never converge. Clamping the
+# outgoing TCP segment size keeps every segment under that ceiling, so sync works on the DEFAULT
+# Tailscale MTU with NO per-node `ip link`/MTU tweaks. Override (or disable with 0) via
+# HIVE_SYNC_MAXSEG.
+SYNC_MAX_SEG = int(os.environ.get("HIVE_SYNC_MAXSEG", "1000"))
+
+
+def _maxseg_supported():
+    """True iff TCP_MAXSEG can actually be lowered on this platform. Linux/WSL/Android: yes.
+    macOS (Darwin) REJECTS it with OSError [Errno 22] — and an unguarded setsockopt inside a
+    urllib3 socket_option would then break EVERY sync connection there — so probe once and skip
+    the clamp where it fails (pagination still carries sync)."""
+    if SYNC_MAX_SEG <= 0 or not hasattr(socket, "TCP_MAXSEG"):
+        return False
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, SYNC_MAX_SEG)
+            return True
+        finally:
+            s.close()
+    except OSError:
+        return False
+
+
+MAXSEG_OK = _maxseg_supported()
+
+
+def clamp_mss(sock):
+    """Best-effort: cap a socket's outgoing TCP segment size to SYNC_MAX_SEG. No-op where the
+    platform can't lower it (see MAXSEG_OK) so callers never have to guard it."""
+    if not MAXSEG_OK:
+        return
+    try:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, SYNC_MAX_SEG)
+    except OSError:
+        pass
+
+
 _hv = None
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -28,6 +28,52 @@ def test_two_node_convergence():
     assert r.returncode == 0, f"sync_smoke.sh failed:\n{r.stdout}\n{r.stderr}"
 
 
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl required for daemon readiness")
+def test_two_node_convergence_under_aggressive_pagination():
+    # Path-MTU resilience: force 1-entry PULL/PUSH pages and a tiny TCP MSS clamp. These change only
+    # the transport granularity (smaller requests, smaller segments) — the G-Set union result must be
+    # byte-identical, so the same harness must still converge. Guards against pagination or the clamp
+    # accidentally dropping/duplicating entries. Runs on macos-latest too (where the clamp no-ops and
+    # pagination alone carries it).
+    env = dict(os.environ, HIVE_SYNC_PULL_PAGE="1", HIVE_SYNC_PUSH_PAGE="1", HIVE_SYNC_MAXSEG="600")
+    r = subprocess.run([str(SMOKE)], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, f"sync_smoke.sh under pagination/clamp failed:\n{r.stdout}\n{r.stderr}"
+
+
+def test_mss_clamp_lowers_segment_size_where_supported():
+    """The MTU fix relies on TCP_MAXSEG genuinely lowering the negotiated MSS where it's settable.
+    On platforms that reject it (macOS [Errno 22]) the clamp must DEGRADE GRACEFULLY — sync_common
+    probes this into MAXSEG_OK and the client/daemon skip the clamp there, so connections never break
+    and pagination carries sync (see the convergence test above, which runs on macos-latest)."""
+    import sync_common
+    if not sync_common.MAXSEG_OK:
+        pytest.skip(f"TCP_MAXSEG not settable on {sys.platform}; pagination is the fallback")
+    clamp = 600
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, clamp)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+    import threading
+    acc = []
+    t = threading.Thread(target=lambda: acc.append(srv.accept()[0]))
+    t.start()
+    cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    cli.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, clamp)
+    cli.connect(("127.0.0.1", port))
+    t.join(5)
+    try:
+        cm = cli.getsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG)
+        sm = acc[0].getsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG)
+        assert cm <= clamp and sm <= clamp, f"TCP_MAXSEG did not clamp MSS: client={cm} server={sm}"
+    finally:
+        cli.close()
+        if acc:
+            acc[0].close()
+        srv.close()
+
+
 def _free_port():
     s = socket.socket()
     s.bind(("127.0.0.1", 0))


### PR DESCRIPTION
Re-applies the closed #21 onto the post-#20 layout (`hive_sync_daemon.py`, `scripts/common/sync_smoke.sh`), **with the macOS fix that CI caught last time.**

## The bug
Some tailnets ride an underlay whose effective path MTU is **below Tailscale's default 1280**, which silently **blackholes full-size packets**. Small responses (`/sync/hello`, `/sync/merkle-root`, `/hive/info`) pass; a multi-KB `/sync/chunk` or `/sync/ingest` **stalls until the read timeout** — so diverged peers never heal and a fresh node can't pull the journal. Measured between two WSL/Tailscale nodes: `/sync/chunk` = **9 ms localhost vs >35 s tailnet**; `ping -M do` drops >~1200-byte packets while `tailscale0` is 1280. (This is what blocked the Z Fold 6 phone from completing its join.)

## Fix (in our code; Tailscale stays at defaults)
1. **Clamp the TCP segment size** (`TCP_MAXSEG`, default 1000, env `HIVE_SYNC_MAXSEG`) on the daemon's listening + accepted sockets and the sync client's connections, via a shared `sync_common.clamp_mss()`.
2. **Paginate** PULL (per-window sub-pages) and PUSH (batched POSTs) into small transfers (`HIVE_SYNC_PULL_PAGE` / `HIVE_SYNC_PUSH_PAGE`, default 25).

## Cross-platform (the macOS lesson)
`setsockopt(TCP_MAXSEG)` raises `[Errno 22]` on macOS, and an unguarded socket-option in the urllib3 adapter would break **every** sync connection there (CI caught exactly this on the first attempt). `sync_common.MAXSEG_OK` **probes once** whether the clamp is settable and skips it where it isn't (macOS) — connections stay healthy and **pagination carries sync**. The clamp-assert test **skips** where `MAXSEG_OK` is false.

## Safety
Pure transport — no wire/protocol change (client already chooses the chunk window; merkle `CHUNK_SIZE=100` untouched), backward compatible, **no `CONTRACT_VERSION` bump**. Safe under concurrent writes (G-Set union keyed by `(node_id, seq)`).

## Verified
- `TCP_MAXSEG` clamps a real connection's MSS **1448 → 988** (Linux).
- Two-node convergence harness passes **normally AND under forced 1-entry pages + MSS 600** (new test). Clamp test skips where unsupported.

## Deploy
Merge → on each node `git fetch --prune origin && git reset --hard origin/main` (post-rewrite history) → `hive-mind update` → the phone's `hv sync now` pulls its owner declaration + admit and completes the join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)