### PR TITLE
feat(install): hive-mind reset — one-command recovery for a wedged node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,11 @@ jobs:
         run: TERMUX_VERSION=1 bash -c '. scripts/installer/_service.sh; runit_uninstall hive-sync; runit_uninstall hive-sync'
       - name: installer scripts lint clean (bash -n)
         run: |
-          for f in install.sh _install_node.sh _service.sh _invite.sh _uninstall.sh _update.sh _status.sh dispatcher.sh; do
+          for f in install.sh _install_node.sh _service.sh _invite.sh _uninstall.sh _update.sh _reset.sh _status.sh dispatcher.sh; do
             bash -n "scripts/installer/$f"
           done
+          bash scripts/installer/_reset.sh --help | grep -q 'reset'      # reset usage works
+          bash scripts/installer/dispatcher.sh help | grep -q 'reset'    # dispatcher routes it
           # Per-OS service backends now live under scripts/platform/<os>/ (see scripts/README.md).
           for f in scripts/platform/linux/_units.sh scripts/platform/macos/_launchd.sh scripts/platform/termux/_runit.sh; do
             bash -n "$f"

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Most of the time your agents call `hv` for you. Full reference:
 | `hive-mind install` | Full device setup from scratch |
 | `hive-mind status`  | Show device health and peer sync state |
 | `hive-mind uninstall` | Remove HiveMind from this device (`--keep-hive` preserves your journal + keys; `--yes` skips the confirmation prompt) |
-| `hive-mind update`  | Pull latest and restart the daemon |
+| `hive-mind update`  | Pull latest and restart the daemon (auto-heals after a force-push / history rewrite) |
+| `hive-mind reset`   | Recover a wedged install: force-align code to `origin` + rebuild + restart + verify. Keeps your Hive data (journal, keys, identity). `-y` skips the prompt. |
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -828,7 +828,8 @@ hive-mind <subcommand> [options]
 | Subcommand | What it does |
 |---|---|
 | `install` | Set up this device from scratch (discovery-driven bootstrap or join). |
-| `update` | Pull the latest code and restart the sync daemon. |
+| `update` | Pull the latest code and restart the sync daemon. **Auto-heals** after a force-push / history rewrite: when a fast-forward isn't possible and the tree is clean, it hard-resets to the upstream instead of aborting. |
+| `reset` | Recover a **wedged** install in one command: force-align the code to `origin` (even after a rewrite, even with local edits), rebuild the DB from the journal, refresh the supervisor units + Claude Code hooks, restart the daemon, and verify authenticity. **Your Hive (journal, keys, device identity) is preserved** — this is not `uninstall`. Use it when `hv doctor`/`hv verify` is unhappy after a breaking change. `-y` skips the prompt. |
 | `status` | Show device health and peer sync state. |
 | `invite` | Print the one-line address to paste on a new device so it can join this hive. |
 | `uninstall` | Remove HiveMind from this device (see flags below). |

--- a/scripts/installer/_reset.sh
+++ b/scripts/installer/_reset.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hive-mind reset  —  scripts/installer/_reset.sh
+#
+# Recover a WEDGED install to a clean, official state — without touching your Hive.
+# Force-aligns the code to origin/<branch> (even after a history rewrite, even with
+# local edits), rebuilds the DB from the journal, refreshes the supervisor units +
+# Claude Code hooks, restarts the sync daemon, and verifies authenticity.
+#
+# PRESERVES your journal, keys, and device identity (all gitignored) — this is NOT
+# `hive-mind uninstall`. Reach for it when `hv doctor`/`hv verify` is unhappy after a
+# breaking change, or when you just want the long post-rewrite incantation as one word.
+#
+# Invoked by: hive-mind reset [-y]
+# =============================================================================
+set -uo pipefail
+
+HIVE_DIR="${HIVE_DIR:-$HOME/projects/hive-mind}"
+SERVICE="hive-sync"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+
+# Supervisor seam (service_install / service_restart) — systemd / launchd / runit.
+_SVCLIB="$HIVE_DIR/scripts/installer/_service.sh"
+[ -f "$_SVCLIB" ] && . "$_SVCLIB"
+
+RED='\033[0;31m'; GRN='\033[0;32m'; YLW='\033[1;33m'; BLD='\033[1m'; RST='\033[0m'
+ok()   { echo -e "${GRN}[ok]${RST}  $*"; }
+info() { echo -e "${BLD}[..]${RST}  $*"; }
+warn() { echo -e "${YLW}[!!]${RST}  $*"; }
+
+ASSUME_YES=""
+for a in "$@"; do
+  case "$a" in
+    -y|--yes)  ASSUME_YES=1 ;;
+    -h|--help) echo "Usage: hive-mind reset [-y]"; echo "  Force-align code to origin + rebuild + restart + verify. Your Hive data is preserved."; exit 0 ;;
+  esac
+done
+
+if [ -z "${HIVE_RESET_REEXEC:-}" ]; then
+  echo ""
+  echo -e "${BLD}hive-mind reset${RST}"
+  echo "────────────────────────────────────"
+  echo "  Force-resets this device's CODE to the official origin and restarts the daemon."
+  echo "  Rebuilds the local DB, refreshes supervision + hooks, and verifies authenticity."
+  echo -e "  Your Hive (journal, keys, device identity) is ${BLD}PRESERVED${RST} — this is not uninstall."
+  echo ""
+  if [ -z "$ASSUME_YES" ] && [ -t 0 ]; then
+    printf "Continue? [y/N] "; read -r _ans
+    case "$_ans" in y|Y|yes|YES) ;; *) echo "Aborted."; exit 0 ;; esac
+  fi
+fi
+
+# ── 1. force-align the code to origin/<branch> (handles rewrites + a dirty tree) ──
+info "Force-aligning code to origin..."
+git -C "$HIVE_DIR" fetch --prune --tags origin 2>&1 | tail -1 || true
+_BR="$(git -C "$HIVE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+[ -z "$_BR" ] || [ "$_BR" = "HEAD" ] && _BR=main
+git -C "$HIVE_DIR" reset --hard "origin/$_BR" 2>&1 | tail -1
+ok "Code at origin/$_BR ($(git -C "$HIVE_DIR" rev-parse --short HEAD 2>/dev/null))"
+
+# Re-exec the freshly-reset copy once so the steps below run the NEW logic (mirrors _update.sh).
+# Guarded so an old checkout that lacks this file degrades gracefully (runs inline).
+if [ -z "${HIVE_RESET_REEXEC:-}" ] && [ -f "$HIVE_DIR/scripts/installer/_reset.sh" ]; then
+  export HIVE_RESET_REEXEC=1
+  exec bash "$HIVE_DIR/scripts/installer/_reset.sh" -y
+fi
+
+# ── 2. relink the commands (new subcommands land without a reinstall) ──
+mkdir -p "$BIN_DIR"
+ln -sf "$HIVE_DIR/scripts/installer/dispatcher.sh" "$BIN_DIR/hive-mind"
+ln -sf "$HIVE_DIR/hv" "$BIN_DIR/hv"
+ok "Commands relinked (hive-mind, hv)"
+
+# ── 3. rebuild store.db from the (preserved) journal ──
+info "Rebuilding database from the journal..."
+( cd "$HIVE_DIR" && ./hv doctor rebuild >/dev/null 2>&1 ) && ok "Database rebuilt" || warn "DB rebuild reported a problem — run 'hv doctor' to inspect."
+
+# ── 4. refresh supervisor units + Claude Code hooks ──
+if command -v service_install >/dev/null 2>&1; then
+  service_install "$HIVE_DIR" "$SERVICE" && ok "Supervisor units refreshed"
+fi
+if [ -d "$HOME/.claude" ] || command -v claude >/dev/null 2>&1; then
+  "$HIVE_DIR/hv" wire claude >/dev/null 2>&1 && ok "Claude Code hooks re-wired" || true
+fi
+
+# ── 5. restart the sync daemon ──
+info "Restarting the sync daemon..."
+if command -v service_restart >/dev/null 2>&1; then
+  service_restart "$SERVICE"
+else
+  systemctl --user restart "$SERVICE" 2>/dev/null || true
+fi
+sleep 2
+curl -sf http://127.0.0.1:9876/sync/hello >/dev/null 2>&1 && ok "Daemon responding on :9876" \
+  || warn "Daemon not yet responding — give it a moment, then check 'hive-mind status'."
+
+# ── 6. verify authenticity (the thing that was failing pre-reset) ──
+info "Verifying authenticity..."
+( cd "$HIVE_DIR" && ./hv verify 2>&1 | head -2 )
+
+echo ""
+ok "Reset complete — your Hive data was preserved. Try: hv stats  /  hv peers"
+echo ""

--- a/scripts/installer/dispatcher.sh
+++ b/scripts/installer/dispatcher.sh
@@ -30,6 +30,7 @@ shift 2>/dev/null || true
 case "$CMD" in
   install)   exec bash "$INSTALLER/_install_node.sh" "$@" ;;
   update)    exec bash "$INSTALLER/_update.sh"       "$@" ;;
+  reset)     exec bash "$INSTALLER/_reset.sh"        "$@" ;;
   status)    exec bash "$INSTALLER/_status.sh"       "$@" ;;
   invite)    exec bash "$INSTALLER/_invite.sh"       "$@" ;;
   uninstall) exec bash "$INSTALLER/_uninstall.sh"    "$@" ;;
@@ -38,7 +39,8 @@ case "$CMD" in
     echo ""
     echo "Subcommands:"
     echo "  install      Set up this device from scratch"
-    echo "  update       Pull latest + restart daemon"
+    echo "  update       Pull latest + restart daemon (auto-heals after a force-push/rewrite)"
+    echo "  reset        Recover a wedged install: force-align code + rebuild + restart + verify (keeps your Hive data)"
     echo "  status       Show device health and peer sync state"
     echo "  invite       Print the address to paste on a new device to join this hive"
     echo "  uninstall    Remove HiveMind from this device (--keep-hive to keep your data)"


### PR DESCRIPTION
## Why
Recovering a node after a breaking change (force-push / history rewrite) meant typing the long incantation `cd ~/projects/hive-mind && git fetch --prune origin && git reset --hard origin/main && hive-mind update` — painful, especially on an Android phone with a tiny keyboard.

## What
**`hive-mind reset`** (`scripts/installer/_reset.sh`) — recover a wedged install in one word:
1. Force-align the code to `origin/<branch>` (even after a rewrite, **even with local edits**).
2. Rebuild the DB from the journal (`hv doctor rebuild`).
3. Refresh the supervisor units + Claude Code hooks.
4. Restart the sync daemon.
5. Verify authenticity (`hv verify`).

**Your Hive (journal, keys, device identity) is preserved** — all gitignored; this is NOT `uninstall`. `-y` skips the prompt. Mirrors `_update.sh`'s re-exec-once pattern (guarded so an old checkout without the file degrades gracefully).

`hive-mind update` *already* auto-heals across a rewrite (#20's `_update.sh` hard-resets a clean tree when a fast-forward isn't possible); `reset` is the explicit hammer that also forces past a **dirty** tree + rebuilds + verifies — the "fix my wedged install" button.

## Verified
- `bash -n` all installer scripts (incl. `_reset.sh`); dispatcher routes `reset`; `_reset.sh --help` works (added to CI).
- **End-to-end run** on a healthy node: force-aligns to `origin/main`, rebuilds, refreshes units/hooks, restarts the daemon (responds on :9876), and verifies **✓ Official HiveMind v1.14** — Hive data preserved.
- Docs: README + CLI_REFERENCE `hive-mind` tables updated (reset + the update auto-heal note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)