### PR TITLE
feat(cell): enforce cell/comb write-authorization under a separate cell_writers policy

### DIFF
--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -1,6 +1,6 @@
 # HiveMind Agent Integration Spec
 
-`Contract-Version: 1.16`  *(SemVer `MAJOR.MINOR`; authoritative value: `hv version`)*
+`Contract-Version: 1.17`  *(SemVer `MAJOR.MINOR`; authoritative value: `hv version`)*
 
 > **Audience: any AI agent** (Claude Code, Hermes, OpenClaw, an MCP host, any CLI agent).
 > You are reading this because you are joining a HiveMind — a shared, local-first memory.
@@ -209,6 +209,16 @@ the deprecation window + graceful degradation prevent hard breakage, and §0 tel
 when it must re-wire.
 
 **Changelog.**
+- `1.17` — **cell/comb write-authorization at the projection**. `_cell_state`/`_comb_state` now apply
+  the same projection authorization as capsules (1.16), but under a **separate `cell_writers` policy**
+  (default `owner`; `fertile` = any admitted device) — so a hive can keep executable definitions
+  owner-only while running capsules fertile, or the reverse. A `cell` defines what an agent or tool
+  runs, so a malicious redefinition is code-injection-equivalent. **Behavior change:** `hv wire --add`
+  was previously ungated (any admitted device could publish a cell/comb); under the default
+  `cell_writers=owner` only the owner may now publish, the CLI refuses a non-owner write, and the
+  projection declines a non-owner-signed cell/comb entry (it still lands in the journal — every node
+  folds it away, convergence-safe). New advisory `cell-authz` doctor check surfaces any now-unhonored
+  definition. `hv config governance set cell_writers owner|fertile`.
 - `1.16` — **capsule write-authorization at the projection**. `_capsule_state` now declines to honor a
   `capsule` entry whose signer was not the authorized writer — under the default `capsule_putters=owner`
   the entry must carry an owner signature from the owner who was legitimate *as of that entry's journal

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -50,6 +50,14 @@ at once). Concretely:
   untouched, so sync stays convergent) — every node just deterministically folds it away. `hv doctor`
   (`capsule-authz`) surfaces any entry the projection declines. Confidentiality is unaffected
   (recipient keys are identity-derived); this protects availability/integrity of the secret.
+- **Redefining an executable `cell`/`comb` by a compromised admitted device.** A `cell` defines what
+  an agent or tool runs and a `comb` orders cells, so a malicious redefinition is code-injection-
+  equivalent — and `hv wire --add` historically appended these with NO write gate. The same
+  projection authorization now applies to `_cell_state`/`_comb_state`, under a SEPARATE `cell_writers`
+  policy (default `owner`) so executable-definition authority is tunable independently of capsule
+  authority (a hive can keep cells owner-only while running capsules fertile). `hv wire --add` refuses
+  an unauthorized write and the projection declines a non-owner-signed cell/comb entry; `hv doctor`
+  (`cell-authz`) surfaces any it declines.
 - **Forged clock to trip succession early.** A quorum election's dead-man timer is anchored on the
   proposal's `basis_ts`. A proposal whose `basis_ts` leads its OWN entry timestamp by more than a
   small skew allowance is rejected — a deterministic, entry-time-only check (no wall-clock), so the

--- a/hv
+++ b/hv
@@ -290,7 +290,7 @@ def _stash_owner_key(seed):
 # output fields within a major). MAJOR = breaking; bump only when unavoidable, keep the previous
 # major working as deprecated shims through a window. Authoritative value; docs/AGENT_INTEGRATION.md
 # documents the same number. See `hv version`.
-CONTRACT_VERSION = "1.16"   # 1.16: capsule write-authorization at the PROJECTION — `_capsule_state` now declines to honor a `capsule` entry whose signer was not the authorized writer (the owner AS OF that entry's journal position under the default `capsule_putters=owner`; any admitted device under `fertile`), closing a hole where a compromised ADMITTED device could supersede or tombstone ANY capsule by appending a journal entry directly, bypassing the CLI-only `capsule_putters` gate (a targeted denial-of-secret). Convergence-safe: the entry still LANDS in every journal/Merkle; every node deterministically folds it away — no ingest/sync/admission change. Owner authority is POINT-IN-TIME via an additive read-only `gov['owner_timeline']`, so a prior owner's seals survive a transfer/succession/election (hive #58). Unsigned capsule entries are declined once an owner exists; a crypto-less (stripped) build keeps honoring (it already hard-fails the `crypto-modules` doctor check) rather than silently emptying capsules (hive #61). New advisory `capsule-authz` doctor check surfaces any now-unhonored entry. cell/comb authz + a separate `cell_writers` policy land in a follow-up PR (hive #60). 1.15: decisions become first-class taggable + searchable — `hv decide --tags` records project/topic tags on a decision (journaled additively in the decision payload; projected to a new `decisions.tags` column; pre-1.15 decisions read back untagged), and `hv search` now ALSO returns matching decisions (LIKE over content/rationale/tags, newest-first, superseded ones flagged) alongside facts, so a project decision is findable by tag/text instead of by its node-local, rebuild-unstable `#id`. `hv search --format json` stays a flat list but each row gains a `kind` discriminator (`fact`|`decision`); a `min_confidence>0` consumer naturally drops decisions (they carry no confidence). MCP `hive_decide` gains a `tags` arg (parity). Additive journal field, wire-compatible; no sync/admission/CLI-removal change. 1.14: standards-anchored crypto — the bundled symmetric layer moved from a hand-rolled SHA-256-CTR keystream + HMAC encrypt-then-MAC to pure-Python ChaCha20-Poly1305 (RFC 8439, `chacha20poly1305.py`), so the self-test pins the RFC's PUBLISHED vector instead of a self-minted byte string and the crypto reviewer audits one analyzed AEAD, not a bespoke composition. `_kdf_keystream` is DELETED. Capsules: alg → `x25519-hkdf-chacha20poly1305-v1` (HKDF-SHA256 over the X25519 ECDH stays; only the cipher changed). Owner-seal: `enc` → `scrypt-chacha20poly1305-v2` (scrypt n 2^15→2^16, params bound as AEAD AAD); the v1 read path is REMOVED (breaking for any pre-1.14 escrow/passphrase-export) — `hv owner restore` skips a retired-scheme escrow with a re-`escrow` hint instead of crashing. New hard-fail `keyperm` doctor check: the raw device/owner seeds at rest must be 0600 (the threat model rests on it); `hv doctor --fix` re-tightens. crypto self-test gains the RFC 8439 AEAD KAT (the symmetric layer previously had NO pinned vector). 1.13: self-wiring primitives, phase 0 — `cell`/`comb` first-class, kind-discriminated journal types (deterministic `_cell_state`/`_comb_state` projections like `_governance_state`; NOT added to `_PASS1`/store.db; they ride sync admission-gated as content). `_wire_claude_hooks` generalized to `_wire_agent(cell)` driven by a built-in Claude `kind:agent` cell (byte-identical; `_wire_claude_hooks` kept as a back-compat shim). New top-level `hv wire <name>|--comb|--list|--show|--add` auto-dispatches by the cell's kind (agent→reconcile foreign config; tool→Phase-1 executor) and ABSORBS `hv doctor wire-agent` (kept as a hidden deprecated alias for one release); installer/updater delegate to `hv wire claude`. Additive journal types are wire-compatible; the wire-verb move is the only CLI break. (Phase 1 tool executor + 5 cells, Phase 2 encrypt-to-device capsules, Phase 3 crypto watchdog land next.) 1.12: self-healing agent integration via a STABLE shim — the Claude Code hooks live in a FOREIGN config (~/.claude/settings.json) the daemon self-heal never owned, so a node updated from before a hook existed could run "healthy" yet silently miss half its hooks. Now ~/.claude registers only a stable shim (`scripts/common/hive_dispatch.sh <event>`, one per lifecycle event); WHICH behaviors run per event is decided inside that script — source-controlled, under `hv verify`'s signature — so new behaviors ship by `git pull`, never by re-wiring ~/.claude (only a new event TYPE changes the spec). `hv` holds the ONE shim spec (`_CLAUDE_HOOK_SPEC`/`_wire_claude_hooks`); `hv doctor` adds an `agent-hooks` check and `hv doctor --fix` (the 15-min `hive-doctor.timer`) reconciles: adds missing shims AND prunes legacy direct hooks (so behaviors never double-fire) + relinks the skill, surgically (own hooks untouched, `.bak.doctor` backup first). `hv doctor wire-agent` exposes it; install.sh + the updater delegate to it (no second definition to drift). Foreign-config integrations only (Claude Code today; Codex later reuses the same dispatcher) — plugin agents (Hermes/OpenClaw/MCP) are our signed code and need no shim. Additive, no wire change; adapters unaffected. 1.11: reconciliation verbs — `hv remember --resolves <id>` links a write to a prior fact it corrects and SOFT-RETRACTS that fact (deliberate negative evidence, reversible, never an owner-forget), recording the link on the new row (`facts.resolves`); a new `hv audit` category CONTRAVENED parses prose references (`resolves/supersedes/obsoletes/corrects #N`) and flags any whose target is still live (un-reconciled), surfaced in the session-start boot summary. Additive, no wire change; adapters unaffected. 1.10: sync robustness — the Merkle index now de-dups the journal by (node_id, seq) before hashing (merkle.read_all_entries), so a physically-repeated journal line can no longer shift a chunk hash and fake a permanent peer "divergence" that ordinary sync cannot heal (append_foreign_entries also de-dups by that key, so a peer's correct copy is rejected as a duplicate and the stray row is never removed); deterministic lexicographic tie-break on the canonical encoding so every node picks the same representative. No wire/CLI change. 1.9: owner resilience pt.3 — QUORUM ELECTION + dead-man switch (Stage C in `_governance_state`): admitted devices `hv owner propose-election`/`vote` to elect a new owner when the chain-current owner has gone dark past `dead_man_days`; device-signed proposals/votes, content-addressed `proposal_id`, deterministic earliest-crossing tie-break; `hv owner heartbeat` refreshes owner liveness (a live owner is never unseated); `hv config quorum set quorum_m|quorum_by|dead_man_days` (quorum_m=0 = OFF, back-compat); `hv owner elections` lists tallies; 1.8: footprint trim — `hv rebuild` folded into `hv doctor rebuild` (top-level `hv rebuild` kept as a hidden deprecated alias, still works); 1.7: owner resilience pt.2 — nominated SUCCESSION (`hv owner nominate`/`claim`) + immediate `hv owner transfer` (the owner-chain in `_governance_state`; a live owner is never unseated, post-handoff old-owner acts drop) + `hv owner revoke-escrow` (logical tombstone so `restore` skips a compromised escrow) + a `doctor` owner check; 1.6: owner resilience pt.1 — `hv owner export/import` (off-device backup/restore; same owner_id resumes) + `hv owner escrow/restore` (passphrase-encrypted owner key stored IN the hive, syncs everywhere) + `hv owner standby` (advisory); 1.5: membership lifecycle (`hv group`) + `hv config` identity/confidence sub-namespaces; 1.4: D0-v2 corroboration — journaled governance, same-device discount, admission gate, CAP_self; 1.3: device identity; 1.2: volatile auto-tag; 1.1: telemetry verb
+CONTRACT_VERSION = "1.17"   # 1.17: cell/comb write-authorization at the PROJECTION — `_cell_state`/`_comb_state` now apply the same projection authorization as capsules (hive #58), but under a SEPARATE `cell_writers` policy (default `owner`; `fertile` = any admitted device), so a hive can keep executable definitions owner-only while running capsules fertile or vice versa (hive #60). A cell DEFINES what an agent/tool runs, so a malicious redefinition is code-injection-equivalent; previously `hv wire --add` appended cell/comb entries with NO write gate, so any admitted device could redefine a cell. BEHAVIOR CHANGE: under the default `cell_writers=owner` only the owner may publish cells/combs — `hv wire --add` now refuses a non-owner write and the projection declines a non-owner-signed cell/comb entry (it still LANDS in the journal; every node folds it away, convergence-safe). Cells/combs are owner-signed on write like capsules; new advisory `cell-authz` doctor check surfaces any now-unhonored definition. Migration-safe on hives with no non-owner cells (the doctor check makes any change visible). 1.16: capsule write-authorization at the PROJECTION — `_capsule_state` now declines to honor a `capsule` entry whose signer was not the authorized writer (the owner AS OF that entry's journal position under the default `capsule_putters=owner`; any admitted device under `fertile`), closing a hole where a compromised ADMITTED device could supersede or tombstone ANY capsule by appending a journal entry directly, bypassing the CLI-only `capsule_putters` gate (a targeted denial-of-secret). Convergence-safe: the entry still LANDS in every journal/Merkle; every node deterministically folds it away — no ingest/sync/admission change. Owner authority is POINT-IN-TIME via an additive read-only `gov['owner_timeline']`, so a prior owner's seals survive a transfer/succession/election (hive #58). Unsigned capsule entries are declined once an owner exists; a crypto-less (stripped) build keeps honoring (it already hard-fails the `crypto-modules` doctor check) rather than silently emptying capsules (hive #61). New advisory `capsule-authz` doctor check surfaces any now-unhonored entry. cell/comb authz + a separate `cell_writers` policy land in a follow-up PR (hive #60). 1.15: decisions become first-class taggable + searchable — `hv decide --tags` records project/topic tags on a decision (journaled additively in the decision payload; projected to a new `decisions.tags` column; pre-1.15 decisions read back untagged), and `hv search` now ALSO returns matching decisions (LIKE over content/rationale/tags, newest-first, superseded ones flagged) alongside facts, so a project decision is findable by tag/text instead of by its node-local, rebuild-unstable `#id`. `hv search --format json` stays a flat list but each row gains a `kind` discriminator (`fact`|`decision`); a `min_confidence>0` consumer naturally drops decisions (they carry no confidence). MCP `hive_decide` gains a `tags` arg (parity). Additive journal field, wire-compatible; no sync/admission/CLI-removal change. 1.14: standards-anchored crypto — the bundled symmetric layer moved from a hand-rolled SHA-256-CTR keystream + HMAC encrypt-then-MAC to pure-Python ChaCha20-Poly1305 (RFC 8439, `chacha20poly1305.py`), so the self-test pins the RFC's PUBLISHED vector instead of a self-minted byte string and the crypto reviewer audits one analyzed AEAD, not a bespoke composition. `_kdf_keystream` is DELETED. Capsules: alg → `x25519-hkdf-chacha20poly1305-v1` (HKDF-SHA256 over the X25519 ECDH stays; only the cipher changed). Owner-seal: `enc` → `scrypt-chacha20poly1305-v2` (scrypt n 2^15→2^16, params bound as AEAD AAD); the v1 read path is REMOVED (breaking for any pre-1.14 escrow/passphrase-export) — `hv owner restore` skips a retired-scheme escrow with a re-`escrow` hint instead of crashing. New hard-fail `keyperm` doctor check: the raw device/owner seeds at rest must be 0600 (the threat model rests on it); `hv doctor --fix` re-tightens. crypto self-test gains the RFC 8439 AEAD KAT (the symmetric layer previously had NO pinned vector). 1.13: self-wiring primitives, phase 0 — `cell`/`comb` first-class, kind-discriminated journal types (deterministic `_cell_state`/`_comb_state` projections like `_governance_state`; NOT added to `_PASS1`/store.db; they ride sync admission-gated as content). `_wire_claude_hooks` generalized to `_wire_agent(cell)` driven by a built-in Claude `kind:agent` cell (byte-identical; `_wire_claude_hooks` kept as a back-compat shim). New top-level `hv wire <name>|--comb|--list|--show|--add` auto-dispatches by the cell's kind (agent→reconcile foreign config; tool→Phase-1 executor) and ABSORBS `hv doctor wire-agent` (kept as a hidden deprecated alias for one release); installer/updater delegate to `hv wire claude`. Additive journal types are wire-compatible; the wire-verb move is the only CLI break. (Phase 1 tool executor + 5 cells, Phase 2 encrypt-to-device capsules, Phase 3 crypto watchdog land next.) 1.12: self-healing agent integration via a STABLE shim — the Claude Code hooks live in a FOREIGN config (~/.claude/settings.json) the daemon self-heal never owned, so a node updated from before a hook existed could run "healthy" yet silently miss half its hooks. Now ~/.claude registers only a stable shim (`scripts/common/hive_dispatch.sh <event>`, one per lifecycle event); WHICH behaviors run per event is decided inside that script — source-controlled, under `hv verify`'s signature — so new behaviors ship by `git pull`, never by re-wiring ~/.claude (only a new event TYPE changes the spec). `hv` holds the ONE shim spec (`_CLAUDE_HOOK_SPEC`/`_wire_claude_hooks`); `hv doctor` adds an `agent-hooks` check and `hv doctor --fix` (the 15-min `hive-doctor.timer`) reconciles: adds missing shims AND prunes legacy direct hooks (so behaviors never double-fire) + relinks the skill, surgically (own hooks untouched, `.bak.doctor` backup first). `hv doctor wire-agent` exposes it; install.sh + the updater delegate to it (no second definition to drift). Foreign-config integrations only (Claude Code today; Codex later reuses the same dispatcher) — plugin agents (Hermes/OpenClaw/MCP) are our signed code and need no shim. Additive, no wire change; adapters unaffected. 1.11: reconciliation verbs — `hv remember --resolves <id>` links a write to a prior fact it corrects and SOFT-RETRACTS that fact (deliberate negative evidence, reversible, never an owner-forget), recording the link on the new row (`facts.resolves`); a new `hv audit` category CONTRAVENED parses prose references (`resolves/supersedes/obsoletes/corrects #N`) and flags any whose target is still live (un-reconciled), surfaced in the session-start boot summary. Additive, no wire change; adapters unaffected. 1.10: sync robustness — the Merkle index now de-dups the journal by (node_id, seq) before hashing (merkle.read_all_entries), so a physically-repeated journal line can no longer shift a chunk hash and fake a permanent peer "divergence" that ordinary sync cannot heal (append_foreign_entries also de-dups by that key, so a peer's correct copy is rejected as a duplicate and the stray row is never removed); deterministic lexicographic tie-break on the canonical encoding so every node picks the same representative. No wire/CLI change. 1.9: owner resilience pt.3 — QUORUM ELECTION + dead-man switch (Stage C in `_governance_state`): admitted devices `hv owner propose-election`/`vote` to elect a new owner when the chain-current owner has gone dark past `dead_man_days`; device-signed proposals/votes, content-addressed `proposal_id`, deterministic earliest-crossing tie-break; `hv owner heartbeat` refreshes owner liveness (a live owner is never unseated); `hv config quorum set quorum_m|quorum_by|dead_man_days` (quorum_m=0 = OFF, back-compat); `hv owner elections` lists tallies; 1.8: footprint trim — `hv rebuild` folded into `hv doctor rebuild` (top-level `hv rebuild` kept as a hidden deprecated alias, still works); 1.7: owner resilience pt.2 — nominated SUCCESSION (`hv owner nominate`/`claim`) + immediate `hv owner transfer` (the owner-chain in `_governance_state`; a live owner is never unseated, post-handoff old-owner acts drop) + `hv owner revoke-escrow` (logical tombstone so `restore` skips a compromised escrow) + a `doctor` owner check; 1.6: owner resilience pt.1 — `hv owner export/import` (off-device backup/restore; same owner_id resumes) + `hv owner escrow/restore` (passphrase-encrypted owner key stored IN the hive, syncs everywhere) + `hv owner standby` (advisory); 1.5: membership lifecycle (`hv group`) + `hv config` identity/confidence sub-namespaces; 1.4: D0-v2 corroboration — journaled governance, same-device discount, admission gate, CAP_self; 1.3: device identity; 1.2: volatile auto-tag; 1.1: telemetry verb
 
 
 # --------------------------------------------------------------------------
@@ -844,14 +844,34 @@ def _projection_latest(entries, want_type, authz=None):
     return out
 
 
-def _cell_state(entries):
-    """name → latest `cell` payload. A cell is an executable unit with a `kind` (`tool`|`agent`)."""
-    return _projection_latest(entries, "cell")
+def _content_authz(gov, policy_key):
+    """The projection authorization callable for an authority-bearing content type governed by the
+    `policy_key` config knob (`capsule_putters` for capsules, `cell_writers` for cells/combs), or None
+    when authz is inactive — pre-owner, or a crypto-less (stripped) build, where the fold stays
+    permissive (hive #61). Default policy is `owner`."""
+    if not gov.get("owner_id") or _ed25519 is None:
+        return None
+    policy = gov.get("config", {}).get(policy_key, "owner")
+    return lambda signer, pos, p: _is_authorized_writer(signer, pos, p, gov, policy)
 
 
-def _comb_state(entries):
-    """name → latest `comb` payload. A comb is a named, ordered collection of cell names."""
-    return _projection_latest(entries, "comb")
+def _cell_state(entries, gov=None):
+    """name → latest `cell` payload. A cell is an executable unit with a `kind` (`tool`|`agent`) — it
+    DEFINES what an agent or tool runs, so a malicious redefinition is as dangerous as code injection.
+    Writes are authorized at the projection like capsules, but under the SEPARATE `cell_writers` policy
+    (default owner — hive decision #60), so a hive can keep cells owner-only while running capsules
+    fertile (or vice versa). Pass `gov` to reuse an already-computed governance projection."""
+    if gov is None:
+        gov = _governance_state(entries)
+    return _projection_latest(entries, "cell", authz=_content_authz(gov, "cell_writers"))
+
+
+def _comb_state(entries, gov=None):
+    """name → latest `comb` payload. A comb is a named, ordered collection of cell names. Authorized
+    under the same `cell_writers` policy as cells (hive #60). Pass `gov` to reuse it."""
+    if gov is None:
+        gov = _governance_state(entries)
+    return _projection_latest(entries, "comb", authz=_content_authz(gov, "cell_writers"))
 
 
 def _capsule_state(entries, gov=None):
@@ -865,11 +885,7 @@ def _capsule_state(entries, gov=None):
     permissively (decision #61). Pass `gov` to reuse an already-computed governance projection."""
     if gov is None:
         gov = _governance_state(entries)
-    authz = None
-    if gov.get("owner_id") and _ed25519 is not None:
-        policy = gov.get("config", {}).get("capsule_putters", "owner")
-        authz = lambda signer, pos, p: _is_authorized_writer(signer, pos, p, gov, policy)
-    return _projection_latest(entries, "capsule", authz=authz)
+    return _projection_latest(entries, "capsule", authz=_content_authz(gov, "capsule_putters"))
 
 
 def _owner_at(owner_timeline, pos):
@@ -924,18 +940,18 @@ def _capsule_version_conflicts(entries):
     return sorted({name for (name, _ver), nodes in seen.items() if len(nodes) > 1})
 
 
-def _capsule_unauthorized(entries, gov):
-    """Capsule entries the projection now DECLINES to honor because their signer was not the
-    authorized writer (the owner AS OF the write position, or an admitted device under `fertile`) —
-    surfaced by `hv doctor` so an operator sees what an upgrade changes rather than silently dropping
-    depended-on state (hive decisions #58/#61). Returns ['name vN by node_id', ...]; empty when authz
-    is inactive (pre-owner or a crypto-less build, where the fold stays permissive)."""
+def _content_unauthorized(entries, gov, want_type, policy_key):
+    """Entries of `want_type` the projection now DECLINES to honor because their signer was not the
+    authorized writer (the owner AS OF the write position, or an admitted device under `fertile`) under
+    the `policy_key` policy — surfaced by `hv doctor` so an operator sees what an upgrade changes rather
+    than silently dropping depended-on state (hive decisions #58/#60/#61). Returns ['name vN by
+    node_id', ...]; empty when authz is inactive (pre-owner or a crypto-less build)."""
     if not gov.get("owner_id") or _ed25519 is None:
         return []
-    policy = gov.get("config", {}).get("capsule_putters", "owner")
+    policy = gov.get("config", {}).get(policy_key, "owner")
     out = []
     for e in entries:
-        if e.get("type") != "capsule":
+        if e.get("type") != want_type:
             continue
         if "sig" in e and not _verify_entry(e):
             continue
@@ -1175,7 +1191,7 @@ def _governance_state_uncached(entries):
                     gov["config"][key] = int(raw)
                 elif key == "quorum_by" and raw in ("device", "principal"):
                     gov["config"][key] = raw
-                elif key == "capsule_putters" and raw in ("owner", "fertile"):
+                elif key in ("capsule_putters", "cell_writers") and raw in ("owner", "fertile"):
                     gov["config"][key] = raw
             except (TypeError, ValueError):
                 pass
@@ -3953,8 +3969,17 @@ def wire_cmd(args):
         if t not in ("cell", "comb") or not payload.get("name"):
             print("JSON must be a cell/comb with a 'name' (type 'cell' or 'comb').")
             return
+        gov = _governance_state(entries)
+        writers = gov.get("config", {}).get("cell_writers", "owner")
+        if gov.get("owner_id"):                 # cells are executable: gate the write (hive #60)
+            if writers == "owner" and _owner_seed() is None:
+                print("Publishing cells/combs is owner-only here (config cell_writers=owner) — the "
+                      "projection would decline a non-owner definition. Run on the owner device, or "
+                      "`hv config governance set cell_writers fertile`."); return
+            if writers == "fertile" and NODE_ID not in gov.get("admitted", set()):
+                print("Only admitted devices may publish cells/combs on this hive."); return
         payload.setdefault("version", 1)
-        append_journal(t, payload)
+        append_journal(t, _authorize_content_payload(payload))
         print(f"Published {t} {payload['name']!r} (version {payload['version']}).")
         return
 
@@ -4131,13 +4156,13 @@ def _my_curve_scalar():
     return _x25519.ed_seed_to_curve_scalar(seed)
 
 
-def _authorize_capsule_payload(payload):
-    """If this device holds the owner key, attach an owner signature so the projection can authorize
-    the write under `capsule_putters=owner` — the writer PROVES owner-key possession, exactly like a
-    governance act (a capsule is otherwise only device-signed). A no-op without the owner key: a
-    fertile-policy write is authorized by device admission and needs no owner_sig. The owner_sig does
-    not enter the capsule AAD (`alg|hive_id|name|version`), so it never affects sealing/opening.
-    Mutates and returns `payload`."""
+def _authorize_content_payload(payload):
+    """If this device holds the owner key, attach an owner signature so the projection can authorize an
+    authority-bearing content write (capsule, cell, comb) under the owner policy — the writer PROVES
+    owner-key possession, exactly like a governance act (the entry is otherwise only device-signed). A
+    no-op without the owner key: a fertile-policy write is authorized by device admission and needs no
+    owner_sig. For capsules the owner_sig is NOT part of the AAD (`alg|hive_id|name|version`), so it
+    never affects sealing/opening. Mutates and returns `payload`."""
     seed = _owner_seed()
     if seed is not None and _ed25519 is not None:
         return _sign_governance_payload(payload, seed, _ed25519.pub_from_seed(seed))
@@ -4189,7 +4214,7 @@ def capsule_cmd(args):
                 print("Only admitted devices may tombstone capsules on this hive."); return 1
         cur = caps.get(args.name)
         nextv = (int(cur.get("version", 0)) + 1) if cur else 1
-        append_journal("capsule", _authorize_capsule_payload(
+        append_journal("capsule", _authorize_content_payload(
             {"capsule_id": hashlib.sha256(args.name.encode()).hexdigest()[:16],
              "name": args.name, "kind": "tombstone", "version": nextv,
              "alg": "tombstone-v1", "wraps": []}))
@@ -4230,7 +4255,7 @@ def capsule_cmd(args):
                 nextv = int(cur.get("version", 0)) + 1
                 cap = _capsule_build(nm, cur.get("kind", "credential"), val,
                                      recips, nextv, gov.get("hive_id", ""), NODE_ID)
-                append_journal("capsule", _authorize_capsule_payload(cap))
+                append_journal("capsule", _authorize_content_payload(cap))
                 sealed = {w["device_id"] for w in cap.get("wraps", [])}
                 unsealable = sorted(set(recips) - sealed)
                 line = f"Rotated {nm!r} → v{nextv} ({len(sealed)} recipient(s))."
@@ -4249,7 +4274,7 @@ def capsule_cmd(args):
         nextv = (int(cur.get("version", 0)) + 1) if cur else 1
         cap = _capsule_build(args.name, "credential", val, recips, nextv,
                              gov.get("hive_id", ""), NODE_ID)
-        append_journal("capsule", _authorize_capsule_payload(cap))
+        append_journal("capsule", _authorize_content_payload(cap))
         sealed = {w["device_id"] for w in cap.get("wraps", [])}
         unsealable = sorted(set(recips) - sealed)
         msg = f"Sealed capsule {args.name!r} v{nextv} to {len(sealed)} device(s)."
@@ -4519,12 +4544,26 @@ def _doctor_status():
     #     write-time, or admitted under fertile). Surfaces what projection authorization drops so a
     #     depended-on secret is never silently unhonored on upgrade (hive #58/#61). Advisory.
     try:
-        unauth = _capsule_unauthorized(entries, gov)
+        unauth = _content_unauthorized(entries, gov, "capsule", "capsule_putters")
         if unauth:
             checks.append({"name": "capsule-authz", "status": "warn",
                            "detail": f"{len(unauth)} capsule entr(y/ies) NOT honored — signer was not "
                                      f"the authorized writer: {', '.join(unauth)} — re-`hv capsule put` "
                                      f"from an authorized device to supersede"})
+    except Exception:
+        pass
+
+    # 3e. Cell/comb (executable definitions) the projection DECLINES under the `cell_writers` policy —
+    #     same surfacing so an upgrade never silently drops a depended-on agent/tool definition
+    #     (hive #60). Advisory.
+    try:
+        unauth = (_content_unauthorized(entries, gov, "cell", "cell_writers")
+                  + _content_unauthorized(entries, gov, "comb", "cell_writers"))
+        if unauth:
+            checks.append({"name": "cell-authz", "status": "warn",
+                           "detail": f"{len(unauth)} cell/comb definition(s) NOT honored — signer was "
+                                     f"not the authorized writer: {', '.join(unauth)} — re-publish with "
+                                     f"`hv wire --add` from an authorized device to supersede"})
     except Exception:
         pass
 
@@ -5392,7 +5431,7 @@ def _config_set(key, value):
     quorum_by, dead_man_days)."""
     coercers = {"same_device_lambda": float, "cap_self": float,
                 "quorum_m": int, "quorum_by": str, "dead_man_days": float,
-                "capsule_putters": str}
+                "capsule_putters": str, "cell_writers": str}
     if key not in coercers:
         print(f"unknown config key {key!r} (known: {', '.join(sorted(coercers))})")
         return
@@ -5404,8 +5443,8 @@ def _config_set(key, value):
     if key == "quorum_by" and val not in ("device", "principal"):
         print("quorum_by must be 'device' or 'principal'")
         return
-    if key == "capsule_putters" and val not in ("owner", "fertile"):
-        print("capsule_putters must be 'owner' (default) or 'fertile' (any admitted device)")
+    if key in ("capsule_putters", "cell_writers") and val not in ("owner", "fertile"):
+        print(f"{key} must be 'owner' (default) or 'fertile' (any admitted device)")
         return
     if key == "quorum_m" and val < 0:
         print("quorum_m must be >= 0 (0 disables elections)")

--- a/tests/test_cell_comb_authz.py
+++ b/tests/test_cell_comb_authz.py
@@ -1,0 +1,150 @@
+"""Projection-level WRITE authorization for cells/combs (PR feat/cell-comb-authz, hive #60).
+
+`_cell_state`/`_comb_state` apply the same authorization as capsules but under a SEPARATE
+`cell_writers` policy (default owner), so executable-definition authority is independent of capsule
+authority. A cell defines what an agent/tool runs, so a non-owner redefinition under the owner policy
+is declined by the projection (and refused by `hv wire --add`).
+"""
+
+import base64
+import importlib.machinery
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT))
+import ed25519  # noqa: E402
+
+
+def _loadhv(home, monkeypatch):
+    monkeypatch.setenv("HIVE_HOME", str(home))
+    loader = importlib.machinery.SourceFileLoader("hvmod_cellauthz", str(PROJECT / "hv"))
+    spec = importlib.util.spec_from_loader("hvmod_cellauthz", loader)
+    m = importlib.util.module_from_spec(spec)
+    loader.exec_module(m)
+    return m
+
+
+def _owner_key(hv):
+    seed = os.urandom(32); pub = hv._ed25519.pub_from_seed(seed)
+    return seed, pub, hv._owner_id_for_pub(pub)
+
+
+def _device_key(hv):
+    seed = os.urandom(32); pub = hv._ed25519.pub_from_seed(seed)
+    return seed, pub, hv._device_id_for_pub(pub)
+
+
+def _gov(hv, payload, oseed, opub, ts, seq=1, nid="ownerdev"):
+    p = hv._sign_governance_payload(payload, oseed, opub)
+    return {"node_id": nid, "seq": seq, "type": "governance", "timestamp": ts, "payload": p}
+
+
+def _content(hv, ctype, name, version, dseed, dpub, ts, seq=1, owner=None, extra=None):
+    """A device-signed cell/comb/capsule entry; `owner=(oseed,opub)` also owner-signs the payload."""
+    payload = {"name": name, "version": version}
+    if extra:
+        payload.update(extra)
+    if owner is not None:
+        payload = hv._sign_governance_payload(payload, owner[0], owner[1])
+    e = {"node_id": hv._device_id_for_pub(dpub), "seq": seq, "type": ctype, "timestamp": ts, "payload": payload}
+    return hv._sign_entry(e, dseed, dpub)
+
+
+def test_cell_nonowner_declined_owner_honored(tmp_path, monkeypatch):
+    hv = _loadhv(tmp_path, monkeypatch)
+    oseed, opub, oid = _owner_key(hv)
+    od_s, od_p, _ = _device_key(hv)            # owner's device
+    d_s, d_p, d_nid = _device_key(hv)          # compromised admitted non-owner
+
+    base = [
+        _gov(hv, {"action": "owner", "owner_id": oid, "hive_id": "h1"}, oseed, opub, "2026-01-01T00:00:00Z", 1),
+        _gov(hv, {"action": "admit", "device_id": d_nid}, oseed, opub, "2026-01-02T00:00:00Z", 2),
+        _content(hv, "cell", "deploy", 1, od_s, od_p, "2026-01-03T00:00:00Z", 3,
+                 owner=(oseed, opub), extra={"kind": "tool", "run": "safe.sh"}),
+    ]
+    # Attacker redefines the executable cell `deploy` by a direct journal append.
+    attack = _content(hv, "cell", "deploy", 2, d_s, d_p, "2026-01-04T00:00:00Z", 1,
+                      extra={"kind": "tool", "run": "evil.sh"})
+    entries = base + [attack]
+    gov = hv._governance_state(entries)
+    cells = hv._cell_state(entries, gov)
+    assert cells["deploy"]["run"] == "safe.sh"                # malicious redefinition DECLINED
+    assert any("deploy v2" in s for s in
+               hv._content_unauthorized(entries, gov, "cell", "cell_writers"))
+    # convergence: the attack entry is still in the raw journal
+    assert any(e["type"] == "cell" and e["payload"].get("run") == "evil.sh" for e in entries)
+
+    # An OWNER-signed redefinition IS honored.
+    legit = base + [_content(hv, "cell", "deploy", 2, od_s, od_p, "2026-01-04T00:00:00Z", 4,
+                             owner=(oseed, opub), extra={"kind": "tool", "run": "safe-v2.sh"})]
+    assert hv._cell_state(legit, hv._governance_state(legit))["deploy"]["run"] == "safe-v2.sh"
+
+
+def test_comb_nonowner_declined(tmp_path, monkeypatch):
+    hv = _loadhv(tmp_path, monkeypatch)
+    oseed, opub, oid = _owner_key(hv)
+    od_s, od_p, _ = _device_key(hv)
+    d_s, d_p, d_nid = _device_key(hv)
+    entries = [
+        _gov(hv, {"action": "owner", "owner_id": oid, "hive_id": "h1"}, oseed, opub, "2026-01-01T00:00:00Z", 1),
+        _gov(hv, {"action": "admit", "device_id": d_nid}, oseed, opub, "2026-01-02T00:00:00Z", 2),
+        _content(hv, "comb", "pipeline", 1, od_s, od_p, "2026-01-03T00:00:00Z", 3,
+                 owner=(oseed, opub), extra={"cells": ["a", "b"]}),
+        _content(hv, "comb", "pipeline", 2, d_s, d_p, "2026-01-04T00:00:00Z", 1,
+                 extra={"cells": ["evil"]}),                 # non-owner supersession
+    ]
+    combs = hv._comb_state(entries, hv._governance_state(entries))
+    assert combs["pipeline"]["cells"] == ["a", "b"]          # non-owner redefinition declined
+
+
+def test_cell_writers_fertile_admitted_honored(tmp_path, monkeypatch):
+    hv = _loadhv(tmp_path, monkeypatch)
+    oseed, opub, oid = _owner_key(hv)
+    d_s, d_p, d_nid = _device_key(hv)
+    entries = [
+        _gov(hv, {"action": "owner", "owner_id": oid, "hive_id": "h1"}, oseed, opub, "2026-01-01T00:00:00Z", 1),
+        _gov(hv, {"action": "set-config", "key": "cell_writers", "value": "fertile"}, oseed, opub, "2026-01-02T00:00:00Z", 2),
+        _gov(hv, {"action": "admit", "device_id": d_nid}, oseed, opub, "2026-01-03T00:00:00Z", 3),
+        _content(hv, "cell", "tool1", 1, d_s, d_p, "2026-01-04T00:00:00Z", 1, extra={"kind": "tool"}),
+    ]
+    gov = hv._governance_state(entries)
+    assert gov["config"]["cell_writers"] == "fertile"
+    assert "tool1" in hv._cell_state(entries, gov)           # fertile: admitted device's cell honored
+
+
+def test_cell_and_capsule_policies_are_independent(tmp_path, monkeypatch):
+    """capsule_putters=fertile but cell_writers=owner (default): an admitted non-owner device's
+    capsule is honored, while its cell is declined — the two policies do not bleed into each other."""
+    hv = _loadhv(tmp_path, monkeypatch)
+    oseed, opub, oid = _owner_key(hv)
+    d_s, d_p, d_nid = _device_key(hv)
+    entries = [
+        _gov(hv, {"action": "owner", "owner_id": oid, "hive_id": "h1"}, oseed, opub, "2026-01-01T00:00:00Z", 1),
+        _gov(hv, {"action": "set-config", "key": "capsule_putters", "value": "fertile"}, oseed, opub, "2026-01-02T00:00:00Z", 2),
+        _gov(hv, {"action": "admit", "device_id": d_nid}, oseed, opub, "2026-01-03T00:00:00Z", 3),
+        _content(hv, "capsule", "TOK", 1, d_s, d_p, "2026-01-04T00:00:00Z", 1, extra={"alg": hv._CAPSULE_ALG, "wraps": []}),
+        _content(hv, "cell", "deploy", 1, d_s, d_p, "2026-01-05T00:00:00Z", 2, extra={"kind": "tool"}),
+    ]
+    gov = hv._governance_state(entries)
+    assert "TOK" in hv._capsule_state(entries, gov)          # capsule fertile → admitted device honored
+    assert "deploy" not in hv._cell_state(entries, gov)      # cell still owner-only → declined
+
+
+def test_point_in_time_prior_owner_cell_survives_transfer(tmp_path, monkeypatch):
+    hv = _loadhv(tmp_path, monkeypatch)
+    a_seed, a_pub, a_oid = _owner_key(hv)
+    b_seed, b_pub, b_oid = _owner_key(hv)
+    ad_s, ad_p, _ = _device_key(hv)
+    entries = [
+        _gov(hv, {"action": "owner", "owner_id": a_oid, "hive_id": "h1"}, a_seed, a_pub, "2026-01-01T00:00:00Z", 1),
+        _content(hv, "cell", "deploy", 1, ad_s, ad_p, "2026-01-02T00:00:00Z", 1,
+                 owner=(a_seed, a_pub), extra={"kind": "tool", "run": "a.sh"}),
+        _gov(hv, {"action": "transfer", "new_owner_pub": base64.b64encode(b_pub).decode()},
+             a_seed, a_pub, "2026-01-03T00:00:00Z", 2),
+    ]
+    gov = hv._governance_state(entries)
+    assert gov["owner_id"] == b_oid
+    assert hv._cell_state(entries, gov)["deploy"]["run"] == "a.sh"   # prior owner's cell survives transfer

--- a/tests/test_projection_authz.py
+++ b/tests/test_projection_authz.py
@@ -80,7 +80,7 @@ def test_nonowner_tombstone_declined_owner_signed_honored(tmp_path, monkeypatch)
     # Convergence: the attack entry still LANDS in the journal; only the projection ignores it.
     assert any(e["type"] == "capsule" and e["payload"].get("alg") == "tombstone-v1" for e in entries)
     # The doctor visibility check surfaces exactly that declined entry.
-    assert any("MYTOK v2" in s for s in hv._capsule_unauthorized(entries, gov))
+    assert any("MYTOK v2" in s for s in hv._content_unauthorized(entries, gov, "capsule", "capsule_putters"))
 
     # The OWNER's own tombstone (owner-signed) IS honored.
     legit = base + [_capsule(hv, "MYTOK", 2, od_s, od_p, "2026-01-04T00:00:00Z", 4, tombstone=True, owner=(oseed, opub))]
@@ -166,4 +166,4 @@ def test_stripped_build_keeps_honoring(tmp_path, monkeypatch):
     monkeypatch.setattr(hv, "_ed25519", None)               # now simulate a crypto-less (stripped) build
     caps = hv._capsule_state(entries, gov)
     assert caps["MYTOK"]["alg"] == "tombstone-v1"            # keeps honoring rather than silently emptying
-    assert hv._capsule_unauthorized(entries, gov) == []     # authz inactive on a stripped build
+    assert hv._content_unauthorized(entries, gov, "capsule", "capsule_putters") == []     # authz inactive on a stripped build


### PR DESCRIPTION
**PR 2 of 2** (follows #39, which closed the same class of hole for capsules). Hive decision #60.

## Threat

A `cell` defines what an agent or tool runs (`kind: tool|agent`) and a `comb` orders cells, so a malicious redefinition is **code-injection-equivalent**. `_cell_state`/`_comb_state` are latest-wins projections, and `hv wire --add` appended cell/comb entries to the journal with **no write gate at all** — so any admitted device could redefine a cell another node will execute.

## Fix — projection-level authorization, separate policy

Applies the same convergence-safe projection authorization PR #39 introduced for capsules (`_content_authz` → `_is_authorized_writer`, point-in-time owner authority via `gov['owner_timeline']`), but under a **separate `cell_writers` policy** (default `owner`; `fertile` = any admitted, non-purged device).

**Why a separate knob, not shared `capsule_putters`:** cells are executable, so their authority should be tunable independently — a hive can keep cells owner-only while running capsules `fertile`, or the reverse. Sharing one knob would mean loosening capsules silently loosens executable-definition authority too. (`test_cell_and_capsule_policies_are_independent` pins this.)

- `hv wire --add` gains the owner/fertile gate and **owner-signs** the cell/comb payload on the owner device (same mechanism as capsules — the writer proves owner-key possession).
- The projection declines a non-owner-signed cell/comb under the owner policy; the entry still lands in every journal and the Merkle is untouched (every node folds it away).
- New advisory **`cell-authz`** doctor check surfaces any declined definition.
- Refactor: shared `_content_authz`; generalized `_authorize_content_payload` and `_content_unauthorized` (was `_capsule_unauthorized`) across capsule/cell/comb.

## Behavior change (called out loudly)

`hv wire --add` was ungated; under the default `cell_writers=owner` **only the owner may now publish cells/combs**. The current hive has **zero journaled cells** (only code-defined built-ins, which are unaffected), so nothing unhonors on upgrade; the `cell-authz` doctor check makes any future before/after visible. `CONTRACT_VERSION` → **1.17**; changelog in `AGENT_INTEGRATION.md`, THREAT_MODEL.md updated.

## Tests

`tests/test_cell_comb_authz.py` (6): non-owner cell/comb declined, owner-signed honored; `cell_writers=fertile` admitted-honored; **capsule/cell policy independence**; point-in-time prior-owner cell survives a transfer. Plus PR #39 tests + capsule/cell/wire/governance/doc-sync suites = **36 pass**. CLI smoke: owner publishes an owner-signed cell (honored); a non-owner member is refused by `hv wire --add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)