### PR TITLE
docs: sync read-authentication + bind hardening (GHSA-242f)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,12 @@ Most of the time your agents call `hv` for you. Full reference:
 - **SQLite** (`store.db`) — a derived index (WAL + FTS5) rebuilt from the journal on any node.
 - **Merkle index** — per-node chunk hashes for efficient delta sync: only missing entries move.
 - **Sync daemon** — a stdlib HTTP server on `:9876` that syncs with peers (every 5 minutes, or
-  on demand). No leader, no central broker. The tailnet is the trust perimeter, but the daemon also
-  caps request bodies, times out slow reads, bounds concurrent requests, and rate-limits per peer,
-  so a single misbehaving peer can't exhaust a node.
+  on demand). No leader, no central broker. The tailnet is the transport perimeter, but the daemon
+  no longer trusts reachability alone: remote peers must **sign their reads** with their device key
+  and be an admitted device (local `127.0.0.1` access stays open), and the daemon binds its own
+  Tailscale IP rather than `0.0.0.0`. It also caps request bodies, times out slow reads, bounds
+  concurrent requests, and rate-limits per peer, so a single misbehaving peer can't exhaust — or
+  silently read — a node. See [`docs/SYNC_API.md`](docs/SYNC_API.md).
 - **Capsules** — share secrets (API keys, tokens) as encrypt-to-device *capsules*: a secret sealed
   so only the devices you've admitted can open it. Each recipient's key is **derived from that
   device's signed identity**, so a capsule can never be sealed to a key a device hasn't proven it

--- a/docs/ADVISORIES.md
+++ b/docs/ADVISORIES.md
@@ -42,6 +42,47 @@ Today only **high-severity crypto** advisories are surfaced automatically; `tool
 severities are documentation that an operator (or an agent reading this file) can consult. The read
 path lives in `hv` (the `doctor` crypto check, around the `advisories.json` load).
 
+## Published advisories
+
+### GHSA-242f-7fxg-f7wm — unauthenticated remote journal disclosure (High, CWE-306)
+
+**Affected:** sync daemon (`hive_sync_daemon.py`) through protocol version 1.
+**Fixed in:** protocol version 2 (read-authentication + bind hardening).
+
+Before the fix, the sync daemon authenticated **writes** (per-entry Ed25519
+signatures on `POST /sync/ingest`) but served **reads** to any host that could
+reach the port. Any device on the tailnet — including a single compromised or
+misbehaving peer — could pull the entire journal off `GET /sync/chunk` /
+`GET /sync/hello` with no credential. The default bind was `0.0.0.0`, widening
+the exposure to every interface, not just the tailnet.
+
+The fix:
+
+- **Read authentication.** Remote reads of journal content (`/sync/hello`,
+  `/sync/chunk`, and `POST /sync/ingest`) now require a signed-request envelope
+  (`Hive-Auth-*` headers) proving the caller is an **admitted device**, with a
+  freshness window and nonce replay guard. Loopback (`127.0.0.1`) — the local
+  operator, `hv`, and the dashboard — stays unauthenticated. Discovery
+  metadata (`/hive/info`, `/sync/merkle-root`, `/api/verify`) stays open but
+  never returns journal content. The dashboard `/api/*` data layer is
+  loopback-only. See `docs/SYNC_API.md`.
+- **Bind hardening.** The daemon now binds its own locally-bindable Tailscale IP
+  (`100.64.0.0/10`), else `127.0.0.1` — never `0.0.0.0` by default. It also binds
+  loopback for the local CLI/dashboard. `HIVE_BIND` remains a deliberate escape
+  hatch; a legacy `0.0.0.0` in `.peers.json` is auto-upgraded on restart. The
+  installer no longer hardcodes the bind.
+- **Phased rollout.** Enforcement is per-node (`off` | `permissive` | `enforce`,
+  default `permissive`), so a mixed-version fleet upgrades without breakage:
+  land the fix → every node reaches protocol 2 in `permissive` (clients sign,
+  nothing breaks) → confirm all peers report `protocol_version` 2 → flip each
+  node to `enforce` with `hv sync auth enforce`. See the rollout runbook in
+  `docs/SYNC_API.md`.
+
+This advisory concerns the **application layer**; it is not a `crypto[]` or
+`tools[]` dependency advisory, so it is not surfaced by `hv doctor` — it is
+recorded here and in the threat model (`docs/THREAT_MODEL.md` §3) as the
+authoritative account of the fix.
+
 ## How to publish a new advisory
 
 It is a normal, signed code change — no special command:

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -209,6 +209,29 @@ the deprecation window + graceful degradation prevent hard breakage, and §0 tel
 when it must re-wire.
 
 **Changelog.**
+- `1.18` — **sync read-authentication + bind hardening** (advisory GHSA-242f-7fxg-f7wm, High,
+  CWE-306). Writes were already authenticated (per-entry signatures on ingest); **reads were open** —
+  any host that could reach the sync port could pull the whole journal off `/sync/chunk`. Now remote
+  reads of journal content (`/sync/hello`, `/sync/chunk`, `POST /sync/ingest`) require a signed-request
+  envelope (`Hive-Auth-*` headers: the client signs, with its Ed25519 device key, over
+  `method + path + sorted-query + sha256(body) + timestamp + nonce`), the daemon verifies the sig,
+  that the signer is in the admitted set, and that the timestamp is fresh (default 300s,
+  `HIVE_SYNC_AUTH_WINDOW`) with a nonce replay guard. **Loopback (`127.0.0.1`) stays unauthenticated**
+  (the local operator, `hv`, and the dashboard); discovery metadata (`/hive/info`,
+  `/sync/merkle-root`, `/api/verify`) stays open but carries no journal content; the dashboard
+  `/api/*` data layer is loopback-only. **Bind hardening:** the daemon binds its own locally-bindable
+  Tailscale IP (`100.64.0.0/10`), else `127.0.0.1` — **never `0.0.0.0`** by default (plus loopback for
+  the local CLI/dashboard); `HIVE_BIND` is the escape hatch, a legacy `0.0.0.0` in `.peers.json`
+  auto-upgrades on restart, and the installer no longer hardcodes bind. `PROTOCOL_VERSION` → **2**
+  (advertised in `/hive/info` + `/sync/hello`, alongside a new `advertised_addr`; `node_id` moved onto
+  `/hive/info`). **Phased rollout, no fleet breakage:** enforcement is per-node
+  (`off` | `permissive` | `enforce`, default `permissive`) via the new **`hv sync auth`** subcommand
+  or `HIVE_SYNC_AUTH` — land the fix → every node reaches protocol 2 in `permissive` (clients sign,
+  nothing breaks) → confirm all peers report `protocol_version` 2 (`curl <peer>/hive/info`) → flip each
+  node to `enforce`. An offline node keeps syncing under `permissive` when it returns. This is the
+  daemon's wire behavior, not the `hv` CLI contract — no verb or flag changes for adapters; only a
+  foreign sync client that reads a peer must adopt the envelope (the bundled `hv`/daemon already do).
+  See `docs/SYNC_API.md` and `docs/ADVISORIES.md`.
 - `1.17` — **cell/comb write-authorization at the projection**. `_cell_state`/`_comb_state` now apply
   the same projection authorization as capsules (1.16), but under a **separate `cell_writers` policy**
   (default `owner`; `fertile` = any admitted device) — so a hive can keep executable definitions

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -733,10 +733,13 @@ decisions — search, filter by tag, sort by salience or recency, filter on stat
 like contested/forgotten/volatile, paginated), **Hive** (peers + health, with live
 sync status), and **Telemetry** (this node's sessions, tokens, and cost over time).
 It's served by the **sync daemon** itself (no extra process): the daemon
-already runs on your sync port, so the dashboard is reachable wherever sync is —
-always on `localhost`, and on your **tailnet IP** so you can open it from another
-device on your tailnet (your laptop, your phone). Nothing is exposed to the public
-internet; it rides the same private path your sync already uses.
+already runs on your sync port, so the dashboard is reachable on `localhost`
+(loopback) on the machine running it. The dashboard SPA and its `/api/*` data
+layer are **loopback-only** — an unauthenticated remote host is refused (they
+carry journal content). To view a node's dashboard from another device, run
+`hv dash` locally on that node, or reach it through a signed peer proxy. Nothing
+is exposed to the public internet; it rides the same private tailnet path your
+sync uses.
 
 `hv dash` prints the URL(s) and tries to open your browser. On a headless box (or
 Android/Termux, or WSL) where it can't, the printed URL is the point — open it
@@ -792,6 +795,7 @@ sets this up for you.
 ```
 hv sync now
 hv sync daemon
+hv sync auth [off|permissive|enforce]
 ```
 
 **Sub-commands:**
@@ -800,11 +804,30 @@ hv sync daemon
 |---|---|
 | `now` | Sync with all peers right now and exit. Good for a manual check. |
 | `daemon` | Run continuously — sync automatically every 5 minutes. This is what the background service runs. |
+| `auth [off\|permissive\|enforce]` | Show or set this node's **read-authentication** enforcement mode. With no argument, prints the current mode. |
+
+**Read authentication (`hv sync auth`).** Since sync protocol version 2, a
+**remote** peer that reads your journal (`/sync/hello`, `/sync/chunk`) must sign
+the request with its device key, and be an admitted device. Local access on
+`127.0.0.1` (your `hv` CLI and dashboard) stays unauthenticated. `hv sync auth`
+controls how strictly your node enforces this:
+
+| Mode | Behavior |
+|---|---|
+| `off` | Legacy — all reads open, no signing required. |
+| `permissive` (default) | Clients sign; your daemon verifies and logs a failure but still serves. Safe while a mixed-version fleet upgrades. |
+| `enforce` | Reject an unauthenticated or invalid remote read with `401`. |
+
+**Rolling it out:** update every node (each reaches protocol 2 in `permissive`
+automatically) → confirm all peers report protocol 2
+(`curl -s http://<peer>:9876/hive/info | jq .protocol_version`) → then
+`hv sync auth enforce` on each node. An offline node keeps syncing under
+`permissive` when it returns, so there's no rush. See `docs/SYNC_API.md` for the
+`Hive-Auth-*` request envelope and the endpoint auth classification.
 
 **`.peers.json` format:**
 ```json
 {
-  "bind": "0.0.0.0",
   "port": 9876,
   "peers": [
     {
@@ -817,7 +840,12 @@ hv sync daemon
 
 - `peers[].url` — your peer's address. Use the WSL Tailscale IP (run `tailscale ip` on the peer to get it).
 - `peers[].node_id` — a label for logs. Optional but helpful.
-- `bind` and `port` — what address and port to listen on. Defaults are fine for most setups.
+- `port` — what port to listen on. The default is fine for most setups.
+- `bind` — optional; what address to listen on. **Omit it** and the daemon binds
+  your own Tailscale IP (`100.64.0.0/10`), else `127.0.0.1` — never `0.0.0.0`. It
+  always also binds loopback so the local CLI/dashboard work. Override with the
+  `HIVE_BIND` env var; a legacy `"bind": "0.0.0.0"` here is auto-upgraded to the
+  tailnet address on restart.
 
 This file is not synced to git — it's specific to each machine.
 
@@ -927,6 +955,9 @@ On the next `hive-mind install`, if a preserved identity is found it offers to *
 | `HIVE_HOME` | The folder containing `hv` | Where your data lives. Override to point `hv` at a different location. |
 | `HIVE_NODE_ID` | The device-key fingerprint, else the hostname | Overrides this device's identity. Normally a node identifies by its Ed25519 device key (see `hv key`); set this only to force an identity, e.g. to run two separate hive instances on one machine. |
 | `HIVE_NODE_LABEL` | Your machine's hostname | A human-friendly display label shown next to the `device_id` in `hv stats` and sync logs. Cosmetic; does not affect identity. |
+| `HIVE_BIND` | Auto: your Tailscale IP (`100.64.0.0/10`), else `127.0.0.1` | The address the sync daemon binds. Overrides the auto-detected default and any `bind` in `.peers.json`. Set `HIVE_BIND=0.0.0.0` as a deliberate escape hatch for unusual NAT/interface setups. The daemon always also binds loopback. |
+| `HIVE_SYNC_AUTH` | `permissive` | Read-authentication enforcement mode (`off` \| `permissive` \| `enforce`) — same as `hv sync auth`. `enforce` rejects unauthenticated/invalid remote reads with `401`; `permissive` verifies but still serves. |
+| `HIVE_SYNC_AUTH_WINDOW` | `300` | Freshness window, in seconds, for a signed read request's timestamp. A request whose `Hive-Auth-Ts` is outside `±` this window is stale (replay guard). |
 | `HIVE_NOW` | System clock | For testing only — pins the clock to a fixed time so results are predictable. |
 
 ---

--- a/docs/P2P_DESIGN.md
+++ b/docs/P2P_DESIGN.md
@@ -130,7 +130,6 @@ representative identical across nodes.
 ```json
 {
   "self": "node-a",
-  "bind": "0.0.0.0",
   "port": 9876,
   "peers": [
     {"id": "node-b", "url": "http://100.64.0.2:9876"}
@@ -138,39 +137,57 @@ representative identical across nodes.
 }
 ```
 
+`bind` is optional and defaults to the node's own locally-bindable Tailscale IP
+(`100.64.0.0/10`), else `127.0.0.1` — never `0.0.0.0` (the daemon also binds
+loopback for the local CLI/dashboard). `HIVE_BIND` overrides; a legacy
+`"bind": "0.0.0.0"` here is auto-upgraded on restart.
+
 ---
 
 ## 5. Sync Protocol (5 endpoints per node)
 
-All endpoints advertise `protocol_version` (`PROTOCOL_VERSION = 1`) so additive
-handshake changes can be negotiated without a journal-schema break.
+All endpoints advertise `protocol_version` (`PROTOCOL_VERSION = 2`) so additive
+handshake changes can be negotiated without a journal-schema break. Version 2
+added **read-authentication**: a remote caller of a content endpoint must present
+a signed-request envelope (`Hive-Auth-*` headers) from an admitted device; see
+`docs/SYNC_API.md` for the envelope and the endpoint auth classification.
 
 ```
-GET /sync/hello
-  -> {"node_id": "...", "hive_id": "...", "protocol_version": 1,
+GET /sync/hello   (remote-auth)
+  -> {"node_id": "...", "hive_id": "...", "protocol_version": 2,
+      "advertised_addr": "100.64.0.2:9876",
       "journal_summary": {"total": 250,
         "by_node": {"node-a": 147, "node-b": 89}},
       "chunks": {"node-a": ["sha256:...", ...], "node-b": [...]}}
   (chunk hashes are folded into hello — no separate chunks endpoint)
 
-GET /sync/merkle-root
+GET /sync/merkle-root   (open discovery)
   -> {"root_hash": "sha256:..."}
 
-GET /sync/chunk?node=X&start=1&end=100
+GET /sync/chunk?node=X&start=1&end=100   (remote-auth)
   -> {"entries": [...], "hash": "sha256:..."}
 
-POST /sync/ingest
+POST /sync/ingest   (remote-auth; content also per-entry signed)
   <- {"entries": [...]}
   -> {"accepted": 42, "duplicates": 3}
 
-GET /hive/info   (discovery; never returns the journal)
-  -> {"hive_id": "...", "owner_id": "...", "label": "...",
-      "node_count": 2, "protocol_version": 1, "genesis": {...}}
+GET /hive/info   (open discovery; never returns the journal)
+  -> {"hive_id": "...", "owner_id": "...", "node_id": "...", "label": "...",
+      "node_count": 2, "protocol_version": 2,
+      "advertised_addr": "100.64.0.2:9876", "genesis": {...}}
 ```
 
+**Auth model.** Remote reads of journal content (`/sync/hello`, `/sync/chunk`,
+`POST /sync/ingest`) require the signed envelope; loopback (`127.0.0.1`) is
+exempt (the local operator/CLI/dashboard); discovery endpoints (`/hive/info`,
+`/sync/merkle-root`, `/api/verify`) stay open but carry no journal content.
+Enforcement is per-node (`off` | `permissive` | `enforce`, default `permissive`)
+via `hv sync auth` / `HIVE_SYNC_AUTH` for a break-free phased rollout.
+
 **Implementation:** Python stdlib `http.server` (`ThreadingHTTPServer` +
-`BaseHTTPRequestHandler`), synchronous, 5 endpoints — no FastAPI dependency.
-Runs on Tailscale interface only (port 9876). See `hive_sync_daemon.py`.
+`BaseHTTPRequestHandler`), synchronous — no FastAPI dependency. Binds the node's
+own Tailscale IP (not `0.0.0.0`) plus loopback, port 9876. See
+`hive_sync_daemon.py`.
 
 ---
 

--- a/docs/SYNC_API.md
+++ b/docs/SYNC_API.md
@@ -1,14 +1,88 @@
 # HiveMind Sync API Reference
 
 The sync daemon (`hive_sync_daemon.py`) exposes a minimal JSON/HTTP API on port
-`:9876` (default). All endpoints are unauthenticated — transport security is
-provided by Tailscale (WireGuard). Only admit Tailscale peers.
+`:9876` (default). Tailscale (WireGuard) is still the transport perimeter — only
+admit Tailscale peers — but the daemon no longer trusts network reachability
+alone. As of **protocol version 2**, remote sync **reads** are authenticated with
+a signed-request envelope (see [Request authentication](#request-authentication)),
+loopback (`127.0.0.1`) requests from the local operator stay unauthenticated, and
+the daemon binds its own tailnet address rather than `0.0.0.0`. This closes
+[GHSA-242f-7fxg-f7wm](ADVISORIES.md) — an unauthenticated remote peer could
+previously read the entire journal off `/sync/chunk`. Writes (`POST /sync/ingest`)
+were already gated by per-entry signatures and remain so.
 
 Start the daemon:
 ```bash
 ./hv sync daemon          # serve + periodic outbound sync (every 5 min)
 python3 hive_sync_daemon.py    # same, direct
 ```
+
+---
+
+## Request authentication
+
+Since protocol version 2, a **remote** request to an authenticated endpoint must
+carry a signed-request envelope. The client signs, with its Ed25519 **device
+key**, over the canonical string
+
+```
+method + "\n" + path + "\n" + sorted-query + "\n" + sha256(body) + "\n" + timestamp + "\n" + nonce
+```
+
+and presents the signature and its identity in HTTP headers:
+
+| Header | Value |
+|---|---|
+| `Hive-Auth-Alg` | `hive-sig-v1` (the envelope scheme id) |
+| `Hive-Auth-Device` | Signer's device id (`k1:…`) |
+| `Hive-Auth-Pub` | Signer's Ed25519 public key, base64 |
+| `Hive-Auth-Ts` | Unix timestamp (seconds) the request was signed |
+| `Hive-Auth-Nonce` | A per-request random nonce (replay guard) |
+| `Hive-Auth-Sig` | base64 Ed25519 signature over the canonical string above |
+
+On receipt the daemon:
+
+1. Verifies `Hive-Auth-Sig` against `Hive-Auth-Pub`, and that
+   `Hive-Auth-Device` is the fingerprint of that pubkey (`k1:` + first 16 hex of
+   `sha256(pub)`) — so a caller can't sign under another device's id.
+2. Requires the signer to be in the governance **admitted set** (an owner or
+   admitted device). A sterile/unknown device is refused.
+3. Checks the timestamp is **fresh** — within `±HIVE_SYNC_AUTH_WINDOW` seconds
+   (default `300`) — and that the nonce hasn't been seen inside that window
+   (replay guard).
+
+**Loopback bypass.** Requests arriving on `127.0.0.1` (the local `hv` CLI, the
+dashboard, or a signed peer proxy) are trusted without an envelope — the local
+operator already holds the keys. Only remote peers must sign.
+
+**Enforcement mode (phased rollout).** Each node runs one of three modes,
+independent of the protocol version it advertises:
+
+| Mode | Behavior |
+|---|---|
+| `off` | Read-auth disabled — legacy behavior, all reads open. |
+| `permissive` (default) | Clients sign every request; the daemon verifies and **logs** a failure but still serves. Nothing breaks while the fleet upgrades. |
+| `enforce` | An unauthenticated or invalid remote request to an authenticated endpoint is rejected (**401**). |
+
+Set the mode with `hv sync auth [off|permissive|enforce]` or the `HIVE_SYNC_AUTH`
+env var. See [Rolling out enforcement](#rolling-out-enforcement) below.
+
+---
+
+## Endpoint authentication classes
+
+The daemon binds **both** loopback (`127.0.0.1`) and its primary tailnet address.
+Every endpoint falls into one of three access classes:
+
+| Class | Endpoints | Who may call |
+|---|---|---|
+| **Open discovery** | `GET /hive/info`, `GET /sync/merkle-root`, `GET /api/verify` | Anyone reachable — no auth. These return metadata only (no journal content), so listing a hive stays open. |
+| **Remote-auth** | `GET /sync/hello`, `GET /sync/chunk`, `POST /sync/ingest` | Loopback (unauthenticated) **or** a signed request from an admitted device. Carries journal content, so remote callers must sign. |
+| **Loopback-only** | all `GET/POST /api/*` (except `/api/verify`) and the dashboard SPA | The local operator on `127.0.0.1`, or a signed peer proxy. Not served to an unauthenticated remote host. |
+
+`POST /sync/ingest` additionally verifies the per-entry signatures on the payload
+(unchanged) — the request envelope authenticates the *caller*, the entry
+signatures authenticate the *content*.
 
 ---
 
@@ -19,12 +93,17 @@ python3 hive_sync_daemon.py    # same, direct
 Node identity and journal summary. Used as the handshake and peer-discovery
 step during a sync round.
 
+**Auth class: remote-auth** — a remote caller must present a signed request
+envelope from an admitted device (loopback is exempt). See
+[Request authentication](#request-authentication).
+
 **Response:**
 ```json
 {
   "node_id": "node-a",
   "hive_id": "k1:2a2110f3d8963a9e",
-  "protocol_version": 1,
+  "protocol_version": 2,
+  "advertised_addr": "100.64.0.2:9876",
   "journal_summary": {
     "total": 48,
     "by_node": {
@@ -48,7 +127,8 @@ step during a sync round.
 |---|---|
 | `node_id` | This device's identity — its device-key fingerprint (`HIVE_NODE_ID` overrides) |
 | `hive_id` | The hive this node belongs to (the founding owner's device id). A client refuses to merge across differing hive ids |
-| `protocol_version` | Sync wire-protocol version (currently `1`). Bumped for additive handshake changes so they can be negotiated without a journal-schema break |
+| `protocol_version` | Sync wire-protocol version (currently `2` — read-authentication capable). Bumped for additive handshake changes so they can be negotiated without a journal-schema break |
+| `advertised_addr` | This node's reachable `host:port` (its tailnet address), so a peer learns where to reach it back without a config round-trip |
 | `journal_summary.by_node` | Highest seq seen per source node — used for quick divergence detection |
 | `chunks` | Per-node array of 100-entry chunk hashes (Merkle leaf hashes). Used to localize which windows need syncing |
 
@@ -77,6 +157,10 @@ transferred). If not → call `/sync/hello` to localize differing chunks.
 ### `GET /sync/chunk`
 
 Fetch a specific 100-entry window of the journal for a given source node.
+
+**Auth class: remote-auth** — this endpoint returns journal content, so a remote
+caller must present a signed request envelope from an admitted device (loopback
+is exempt). This is the read that GHSA-242f-7fxg-f7wm closed.
 
 **Query parameters:**
 
@@ -165,16 +249,21 @@ hardening for a future release.
 
 Discovery endpoint: minimal hive metadata plus the signed genesis (owner
 declaration) for verification. Never returns journal entries — so listing a
-hive stays open even if reads are gated later.
+hive (and confirming its protocol version during a rollout) stays open.
+
+**Auth class: open discovery** — unauthenticated. Returns metadata only, no
+journal content.
 
 **Response:**
 ```json
 {
   "hive_id": "k1:2a2110f3d8963a9e",
   "owner_id": "k1:2a2110f3d8963a9e",
+  "node_id": "k1:10f6b761dd1c2a90",
   "label": "node-a",
   "node_count": 2,
-  "protocol_version": 1,
+  "protocol_version": 2,
+  "advertised_addr": "100.64.0.2:9876",
   "genesis": { "node_id": "k1:...", "seq": 1, "type": "governance", "payload": { ... } }
 }
 ```
@@ -183,9 +272,11 @@ hive stays open even if reads are gated later.
 |---|---|
 | `hive_id` | The hive's identity (the founding owner's device id) — scopes all sync; cross-hive merges are refused |
 | `owner_id` | Current owner's device id from governance state |
+| `node_id` | This device's own identity (its device-key fingerprint). Moved here so discovery can name the responder without a `/sync/hello` round-trip |
 | `label` | This node's human-readable label (`HIVE_NODE_LABEL`) |
 | `node_count` | Number of admitted nodes (falls back to the count of distinct authoring nodes if no admit set exists) |
-| `protocol_version` | Sync wire-protocol version (see `/sync/hello`) |
+| `protocol_version` | Sync wire-protocol version (see `/sync/hello`). `2` = read-authentication capable — poll this across peers to confirm a fleet is ready to `enforce` |
+| `advertised_addr` | This node's reachable `host:port` (its tailnet address) |
 | `genesis` | The signed owner declaration entry, for independent verification of the hive's origin |
 
 ---
@@ -337,7 +428,6 @@ alongside `action`.
       "node_id": "k1:597b3e0f5fb92d37"
     }
   ],
-  "bind": "0.0.0.0",
   "port": 9876
 }
 ```
@@ -346,8 +436,14 @@ alongside `action`.
 |---|---|---|
 | `peers[].url` | required | Base URL of the peer's sync daemon |
 | `peers[].node_id` | optional | The peer's device id (`k1:…`), for logging and the admitted-peer set |
-| `bind` | `0.0.0.0` | Interface to bind the daemon to |
+| `bind` | auto | Interface to bind the daemon to. **Default is the node's own locally-bindable Tailscale IP (`100.64.0.0/10`), else `127.0.0.1` — never `0.0.0.0`.** Omit it and the daemon picks the right address. Set it only to override; `HIVE_BIND` in the environment takes precedence. A legacy `"bind": "0.0.0.0"` left in this file is auto-upgraded to the tailnet address on restart. |
 | `port` | `9876` | Port the daemon listens on |
+
+The daemon always binds **loopback in addition to** its primary address, so the
+local `hv` CLI and dashboard reach it on `127.0.0.1` regardless of `bind`.
+`0.0.0.0` is still available as a deliberate escape hatch via `HIVE_BIND=0.0.0.0`
+(e.g. an unusual NAT/interface setup) — it is no longer the default and the
+installer no longer hardcodes it.
 
 Get a node's device id and public key with `hv config identity show` on that machine.
 
@@ -355,9 +451,10 @@ Get a node's device id and public key with `hv config identity show` on that mac
 `config/.peers.json.example` and edit per node.
 
 **WSL + Tailscale note:** Each WSL2 instance gets its own Tailscale IP (appears
-as a separate machine on the tailnet, e.g. `node-a-1`). The sync daemon
-binds `0.0.0.0:9876` and is reachable directly at the WSL Tailscale IP. No
-portproxy or mirrored networking needed. Get the WSL IP with `tailscale ip`.
+as a separate machine on the tailnet, e.g. `node-a-1`). The sync daemon binds
+that WSL Tailscale IP (auto-detected) plus loopback, and is reachable directly
+at the WSL Tailscale IP. No portproxy or mirrored networking needed. Get the WSL
+IP with `tailscale ip`.
 
 **macOS note:** Install Tailscale via the app (App Store / standalone) or
 `brew install tailscale`; the app or `brew services` owns `tailscaled` (the
@@ -375,8 +472,40 @@ All endpoints return JSON on error:
 {"error": "description"}
 ```
 
-HTTP status codes: `200` success, `404` unknown path, `409` cross-hive push
-refused (`POST /sync/ingest` when the sender's `hive_id` differs from this
-node's), `500` internal error. A 409 body carries `{"error": "different hive",
-"hive_id": "<local>", "accepted": 0}`. The daemon never crashes a handler
-thread — all exceptions are caught and returned as 500.
+HTTP status codes: `200` success, `401` request-authentication failure (a remote
+call to a remote-auth or loopback-only endpoint with a missing/invalid/stale
+envelope, or a signer not in the admitted set — returned only under
+`HIVE_SYNC_AUTH=enforce`; `permissive` logs and serves), `404` unknown path,
+`409` cross-hive push refused (`POST /sync/ingest` when the sender's `hive_id`
+differs from this node's), `500` internal error. A 409 body carries
+`{"error": "different hive", "hive_id": "<local>", "accepted": 0}`. The daemon
+never crashes a handler thread — all exceptions are caught and returned as 500.
+
+---
+
+## Rolling out enforcement
+
+Read-authentication ships behind a per-node enforcement mode so a mixed-version
+fleet never breaks mid-upgrade. The rollout is:
+
+1. **Land the fix on every node.** Each updated daemon advertises
+   `protocol_version: 2` and defaults to `HIVE_SYNC_AUTH=permissive` — clients
+   sign every request, the daemon verifies and logs failures but still serves.
+   Nothing breaks while nodes update at their own pace (an offline node keeps
+   syncing under `permissive` when it returns).
+2. **Confirm the whole fleet reports protocol 2.** Poll each peer:
+   ```bash
+   curl -s http://<peer>:9876/hive/info | jq .protocol_version    # expect 2
+   ```
+   `/hive/info` is open discovery, so this needs no auth.
+3. **Flip each node to `enforce`, one at a time.** Once every peer reports
+   protocol 2 (so every client is signing), run on each node:
+   ```bash
+   hv sync auth enforce
+   ```
+   From then on that node rejects an unauthenticated or invalid remote read with
+   `401`. Local (`127.0.0.1`) access is unaffected.
+
+To pause enforcement on a node, `hv sync auth permissive` (or `off`). See
+`docs/CLI_REFERENCE.md` for the `hv sync auth` subcommand and the
+`HIVE_SYNC_AUTH` / `HIVE_SYNC_AUTH_WINDOW` / `HIVE_BIND` environment variables.


### PR DESCRIPTION
## What

Documents the just-implemented **sync read-authentication + bind hardening** fix for advisory **GHSA-242f-7fxg-f7wm** (High, CWE-306), which lands as sync **protocol version 2**. Docs only — no source or test changes.

Writes to the sync daemon were already authenticated (per-entry Ed25519 signatures on ingest); **reads were open** — any host that could reach `:9876` could pull the entire journal off `/sync/chunk`, and the default bind was `0.0.0.0`. The fix requires remote reads to be signed, keeps loopback open, and binds the node's own tailnet IP.

## Files changed

- **docs/SYNC_API.md** — new *Request authentication* section (the `Hive-Auth-*` signed-request envelope: `method + path + sorted-query + sha256(body) + timestamp + nonce`, freshness window `HIVE_SYNC_AUTH_WINDOW`, nonce replay guard, admitted-set check); *Endpoint authentication classes* table (open-discovery / remote-auth / loopback-only); `protocol_version` 2, `advertised_addr`, `node_id` on `/hive/info`; bind default is the Tailscale IP not `0.0.0.0`; `401` error code; *Rolling out enforcement* runbook.
- **docs/CLI_REFERENCE.md** — `hv sync auth [off|permissive|enforce]` subcommand; `HIVE_SYNC_AUTH`, `HIVE_BIND`, `HIVE_SYNC_AUTH_WINDOW` env vars; dashboard `/api/*` clarified as loopback-only.
- **docs/ADVISORIES.md** — GHSA-242f entry (unauthenticated journal disclosure → read-auth + bind hardening).
- **docs/P2P_DESIGN.md** — protocol-2 endpoint auth classes, `advertised_addr`, bind change, peer-registry example.
- **docs/AGENT_INTEGRATION.md** — `1.18` changelog entry.
- **README.md** — sync daemon now signs remote reads and binds the tailnet IP.

## Rollout (documented)

Land fix → every node reaches protocol 2 in `permissive` (clients sign, nothing breaks) → confirm all peers report `protocol_version` 2 (`curl <peer>/hive/info`) → flip each node to `enforce`. Offline nodes keep syncing under `permissive`.

## Not touched

`docs/THREAT_MODEL.md` (its §3 is rewritten by the code-fix PR — avoiding a conflict) and `verify.json`/`verify.json.sig` (CI-signed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)